### PR TITLE
define MJSONWP instead of OSS

### DIFF
--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -16,8 +16,8 @@ module Appium
           capabilities = bridge.create_session(desired_capabilities)
 
           case bridge.dialect
-          when :oss
-            CoreBridgeOSS.new(capabilities, bridge.session_id, opts)
+          when :oss # for MJSONWP
+            CoreBridgeMJSONWP.new(capabilities, bridge.session_id, opts)
           when :w3c
             CoreBridgeW3C.new(capabilities, bridge.session_id, opts)
           else
@@ -26,17 +26,17 @@ module Appium
         end
       end # class Bridge
 
-      class CoreBridgeOSS < ::Selenium::WebDriver::Remote::OSS::Bridge
+      class CoreBridgeMJSONWP < ::Selenium::WebDriver::Remote::OSS::Bridge
         def commands(command)
-          ::Appium::Core::Commands::COMMANDS_EXTEND_OSS[command]
+          ::Appium::Core::Commands::COMMANDS_EXTEND_MJSONWP[command]
         end
-      end # class CoreBridgeOSS
+      end # class CoreBridgeMJSONWP
 
       class CoreBridgeW3C < ::Selenium::WebDriver::Remote::W3C::Bridge
         def commands(command)
           case command
           when :status, :is_element_displayed
-            ::Appium::Core::Commands::COMMANDS_EXTEND_OSS[command]
+            ::Appium::Core::Commands::COMMANDS_EXTEND_MJSONWP[command]
           else
             ::Appium::Core::Commands::COMMANDS_EXTEND_W3C[command]
           end

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -16,7 +16,7 @@ module Appium
         def initialize(opts = {})
           listener = opts.delete(:listener)
           @bridge = ::Appium::Core::Base::Bridge.handshake(opts)
-          if @bridge.dialect == :oss
+          if @bridge.dialect == :oss # MJSONWP
             extend ::Selenium::WebDriver::DriverExtensions::HasTouchScreen
             extend ::Selenium::WebDriver::DriverExtensions::HasLocation
             extend ::Selenium::WebDriver::DriverExtensions::HasNetworkConnection

--- a/lib/appium_lib_core/common/command.rb
+++ b/lib/appium_lib_core/common/command.rb
@@ -70,7 +70,7 @@ module Appium
       COMMANDS = {}.merge(COMMAND).merge(COMMAND_ANDROID).merge(COMMAND_IOS)
                    .merge(COMMAND_NO_ARG).freeze
 
-      COMMANDS_EXTEND_OSS = COMMANDS.merge(::Appium::Core::Base::Commands::OSS).freeze
+      COMMANDS_EXTEND_MJSONWP = COMMANDS.merge(::Appium::Core::Base::Commands::OSS).freeze
       COMMANDS_EXTEND_W3C = COMMANDS.merge(::Appium::Core::Base::Commands::W3C).freeze
     end
   end

--- a/lib/appium_lib_core/common/device.rb
+++ b/lib/appium_lib_core/common/device.rb
@@ -283,8 +283,8 @@ module Appium
             end
           end
 
-          # TODO: Don't define selenium-side methods. We pick up from them.
-          # ::Appium::Core::Base::Commands::OSS.each_key do |method|
+          # Don't define selenium-side methods. We pick up from them.
+          # ::Appium::Core::Base::Commands::MJSONWP.each_key do |method|
           #   add_endpoint_method method
           # end
 
@@ -447,7 +447,7 @@ module Appium
 
         # @private
         def create_bridge_command(method)
-          ::Appium::Core::Base::CoreBridgeOSS.class_eval do
+          ::Appium::Core::Base::CoreBridgeMJSONWP.class_eval do
             block_given? ? class_eval(&Proc.new) : define_method(method) { execute method }
           end
           ::Appium::Core::Base::CoreBridgeW3C.class_eval do

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -19,10 +19,6 @@ class AppiumLibCoreTest
         assert size.height
       end
 
-      def parameterized_method_defined_check(array)
-        array.each { |v| assert ::Appium::Core::Base::CoreBridgeOSS.method_defined?(v) }
-      end
-
       def test_shake
         skip
         assert @@driver.shake

--- a/test/unit/android/device_test.rb
+++ b/test/unit/android/device_test.rb
@@ -14,7 +14,7 @@ class AppiumLibCoreTest
       end
 
       def parameterized_method_defined_check(array)
-        array.each { |v| assert ::Appium::Core::Base::CoreBridgeOSS.method_defined?(v) }
+        array.each { |v| assert ::Appium::Core::Base::CoreBridgeMJSONWP.method_defined?(v) }
         array.each { |v| assert ::Appium::Core::Base::CoreBridgeW3C.method_defined?(v) }
       end
 

--- a/test/unit/ios/device_test.rb
+++ b/test/unit/ios/device_test.rb
@@ -14,7 +14,7 @@ class AppiumLibCoreTest
       end
 
       def parameterized_method_defined_check(array)
-        array.each { |v| assert ::Appium::Core::Base::CoreBridgeOSS.method_defined?(v) }
+        array.each { |v| assert ::Appium::Core::Base::CoreBridgeMJSONWP.method_defined?(v) }
         array.each { |v| assert ::Appium::Core::Base::CoreBridgeW3C.method_defined?(v) }
       end
 


### PR DESCRIPTION
Use `MJSONWP` instead of `OSS` to fit the other name rule.
(For the webdriver side, we use `OSS` for mobile JSON protocol.)