### PR TITLE
add adding appium-prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Enhancements
+- Append `appium:` prefix for capabilities automatically due to W3C format.
 
 ### Bug fixes
 

--- a/appium_lib_core.gemspec
+++ b/appium_lib_core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'selenium-webdriver', '~> 3.4', '>= 3.4.1'
+  spec.add_runtime_dependency 'selenium-webdriver', '~> 3.5'
   spec.add_runtime_dependency 'json', '>= 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.14'

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -2,6 +2,16 @@ module Appium
   module Core
     class Base
       class Bridge < ::Selenium::WebDriver::Remote::Bridge
+        # Almost same as self.handshake in ::Selenium::WebDriver::Remote::Bridge
+        #
+        # Implements protocol handshake which:
+        #
+        #   1. Creates session with driver.
+        #   2. Sniffs response.
+        #   3. Based on the response, understands which dialect we should use.
+        #
+        # @return [CoreBridgeMJSONWP, CoreBridgeW3C]
+        #
         def self.handshake(**opts)
           desired_capabilities = opts.delete(:desired_capabilities)
 
@@ -25,6 +35,11 @@ module Appium
           end
         end
 
+        # Append `appium:` prefix for Appium following W3C spec
+        # https://www.w3.org/TR/webdriver/#dfn-validate-capabilities
+        #
+        # @param [::Selenium::WebDriver::Remote::W3C::Capabilities, Hash] capabilities A capability
+        # @return [::Selenium::WebDriver::Remote::W3C::Capabilities]
         def add_appium_prefix(capabilities)
           w3c_capabilities = ::Selenium::WebDriver::Remote::W3C::Capabilities.new
 

--- a/test/unit/common_test.rb
+++ b/test/unit/common_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+
+# $ rake test:unit TEST=test/unit/common_test.rb
+class AppiumLibCoreTest
+  class Common
+    class AppiumCoreBaseBridgeTest < Minitest::Test
+      def setup
+        @bridge = Appium::Core::Base::Bridge.new
+      end
+
+      def test_add_appium_prefix_compatible_with_oss
+        cap = {
+          platformName: :ios,
+          automationName: 'XCUITest',
+          app: 'test/functional/app/UICatalog.app',
+          platformVersion: '10.3',
+          deviceName: 'iPhone Simulator',
+          useNewWDA: true,
+          some_capability: 'some_capability'
+        }
+        base_caps = Appium::Core::Base::Capabilities.create_capabilities(cap)
+
+        expected = {
+          proxy: nil,
+          platformName: :ios,
+          'appium:automationName' => 'XCUITest',
+          'appium:app' => 'test/functional/app/UICatalog.app',
+          'appium:platformVersion' => '10.3',
+          'appium:deviceName' => 'iPhone Simulator',
+          'appium:useNewWDA' => true,
+          'appium:some_capability' => 'some_capability'
+        }
+
+        assert_equal expected, @bridge.add_appium_prefix(base_caps).__send__(:capabilities)
+      end
+
+      def test_add_appium_prefix_already_have_appium_prefix
+        cap = {
+          platformName: :ios,
+          automationName: 'XCUITest',
+          'appium:app' => 'test/functional/app/UICatalog.app',
+          platformVersion: '10.3',
+          deviceName: 'iPhone Simulator',
+          useNewWDA: true,
+          some_capability: 'some_capability'
+        }
+        base_caps = Appium::Core::Base::Capabilities.create_capabilities(cap)
+
+        expected = {
+          proxy: nil,
+          platformName: :ios,
+          'appium:automationName' => 'XCUITest',
+          'appium:app' => 'test/functional/app/UICatalog.app',
+          'appium:platformVersion' => '10.3',
+          'appium:deviceName' => 'iPhone Simulator',
+          'appium:useNewWDA' => true,
+          'appium:some_capability' => 'some_capability'
+        }
+
+        assert_equal expected, @bridge.add_appium_prefix(base_caps).__send__(:capabilities)
+      end
+
+      def test_add_appium_prefix_has_no_parameter
+        cap = {}
+        base_caps = Appium::Core::Base::Capabilities.create_capabilities(cap)
+        expected = { proxy: nil }
+
+        assert_equal expected, @bridge.add_appium_prefix(base_caps).__send__(:capabilities)
+      end
+    end
+  end
+end


### PR DESCRIPTION
ref: https://github.com/appium/ruby_lib_core/pull/31#issuecomment-352667828

## TODO
- [x] check compatibility for previous appium server
- [x] add a unit test
- [x] refactor include fixing rubocop
- [x] pass functional tests

## Ruby
```
pry(#<Appium::Core::Base::Bridge>)> add_prefix(desired_capabilities)
=> #<Selenium::WebDriver::Remote::W3C::Capabilities:0x007fe564253748
 @capabilities=
  {:proxy=>nil,
   :platformName=>:ios,
   "appium:automationName"=>"XCUITest",
   "appium:app"=>"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app",
   "appium:platformVersion"=>"10.3",
   "appium:deviceName"=>"iPhone Simulator",
   "appium:useNewWDA"=>true,
   "appium:some_capability"=>"some_capability"}>
```

## Appium
```
[HTTP] --> POST /wd/hub/session {"desiredCapabilities":{"platformName":"ios","automationName":"XCUITest","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app","platformVersion":"10.3","deviceName":"iPhone Simulator","useNewWDA":true,"someCapability":"some_capability"},"capabilities":{"firstMatch":[{"platformName":"ios","appium:automationName":"XCUITest","appium:app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app","appium:platformVersion":"10.3","appium:deviceName":"iPhone Simulator","appium:useNewWDA":true,"appium:some_capability":"some_capability"}]}}
[debug] [MJSONWP] Calling AppiumDriver.createSession() with args: [{"platformName":"ios","automationName":"XCUITest","app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app","platformVersion":"10.3","deviceName":"iPhone Simulator","useNewWDA":true,"someCapability":"some_capability"},null,{"firstMatch":[{"platformName":"ios","appium:automationName":"XCUITest","appium:app":"/Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app","appium:platformVersion":"10.3","appium:deviceName":"iPhone Simulator","appium:useNewWDA":true,"appium:some_capability":"some_capability"}]}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1513691671112 (22:54:31 GMT+0900 (JST))
[BaseDriver] ["appium:automationName","appium:app","appium:platformVersion","appium:deviceName","appium:useNewWDA","appium:some_capability"] are not standard capabilities and should have an extension prefix
[Appium] Creating new XCUITestDriver (v2.61.0) session
[Appium] Capabilities:
[Appium]   platformName: ios
[Appium]   automationName: XCUITest
[Appium]   app: /Users/kazuaki/GitHub/ruby_lib_core/test/functional/app/UICatalog.app
[Appium]   platformVersion: 10.3
[Appium]   deviceName: iPhone Simulator
[Appium]   useNewWDA: true
[Appium]   some_capability: some_capability
[BaseDriver] The following capabilities were provided, but are not recognized by appium: some_capability.
[BaseDriver] Session created with session id: f59e4bfd-3624-41de-8c8e-dbb7dddd87c5
[debug] [XCUITest] Current user: 'kazuaki'
[debug] [XCUITest] Current version of libimobiledevice: stable 1.2.0 (bottled), HEAD
[debug] [XCUITest] Xcode version set to '9.2'
[debug] [XCUITest] iOS SDK Version set to '11.2'
```