### PR TITLE
Switchable w3c format caps from capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Enhancements
+- Refactor `create_session` in `Appium::Core::Base::Bridge`
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Enhancements
 - Refactor `create_session` in `Appium::Core::Base::Bridge`
-- Be able to communicate with Appium by `W3C` based webdriver protocol
-    - Read API doc for `Appium::Core::Base::Bridge#create_session` and its example
-    - By default, the client try to communicate by `mjsonwp` based protocol
+- Be able to communicate with Appium by `W3C` based webdriver protocol if the Appium supports W3C protocol.
+    - If `force_mjsonwp: true` exists in the capability, the client try to communicate `mjsonwp` based protocol
+        - By default, `force_mjsonwp: false`
+    - Read API doc for `Appium::Core::Base::Bridge#create_session` to read the example of `forceforce_mjsonwp`
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Enhancements
 - Refactor `create_session` in `Appium::Core::Base::Bridge`
+- Be able to `W3C` protocol based Appium feature.
+    - Read API doc for `Appium::Core::Base::Bridge#create_session` and its example.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - Refactor `create_session` in `Appium::Core::Base::Bridge`
 - Be able to communicate with Appium by `W3C` based webdriver protocol if the Appium supports W3C protocol.
     - If `forceMjsonwp: true` exists in the capability, the client try to communicate `mjsonwp` based protocol
-        - By default, `forceMjsonwp: false`
+        - By default, it depends on the response from the server
     - Read API doc for `Appium::Core::Base::Bridge#create_session` to read the example of `forceMjsonwp`
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 - Refactor `create_session` in `Appium::Core::Base::Bridge`
 - Be able to communicate with Appium by `W3C` based webdriver protocol if the Appium supports W3C protocol.
-    - If `force_mjsonwp: true` exists in the capability, the client try to communicate `mjsonwp` based protocol
-        - By default, `force_mjsonwp: false`
-    - Read API doc for `Appium::Core::Base::Bridge#create_session` to read the example of `forceforce_mjsonwp`
+    - If `forceMjsonwp: true` exists in the capability, the client try to communicate `mjsonwp` based protocol
+        - By default, `forceMjsonwp: false`
+    - Read API doc for `Appium::Core::Base::Bridge#create_session` to read the example of `forceMjsonwp`
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Enhancements
 - Refactor `create_session` in `Appium::Core::Base::Bridge`
-- Be able to `W3C` protocol based Appium feature.
-    - Read API doc for `Appium::Core::Base::Bridge#create_session` and its example.
+- Be able to communicate with Appium by `W3C` based webdriver protocol
+    - Read API doc for `Appium::Core::Base::Bridge#create_session` and its example
+    - By default, the client try to communicate by `mjsonwp` based protocol
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -47,6 +47,25 @@ module Appium
         # @param [::Selenium::WebDriver::Remote::W3C::Capabilities, Hash] capabilities A capability
         # @return [::Selenium::WebDriver::Remote::Capabilities, ::Selenium::WebDriver::Remote::W3C::Capabilities]
         #
+        # @example
+        #
+        #   opts = {
+        #     caps: {
+        #       platformName: :ios,
+        #       automationName: 'XCUITest',
+        #       app: 'test/functional/app/UICatalog.app',
+        #       platformVersion: '10.3',
+        #       deviceName: 'iPhone Simulator',
+        #       useNewWDA: true,
+        #       w3c: true
+        #     },
+        #     appium_lib: {
+        #       wait: 30
+        #     }
+        #   }
+        #   core = ::Appium::Core.for(self, caps)
+        #   driver = core.start_driver #=> driver.dialect == :w3c
+        #
         def create_session(desired_capabilities)
           w3c = desired_capabilities[:w3c] || false
 

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -25,9 +25,6 @@ module Appium
             desired_capabilities = Remote::Capabilities.__send__(desired_capabilities)
           end
 
-          require 'pry'
-          binding.pry
-
           bridge = new(opts)
           capabilities = bridge.create_session(desired_capabilities)
 

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -147,7 +147,7 @@ module Appium
               desiredCapabilities: desired_capabilities,
               capabilities: {
                 alwaysMatch: w3c_capabilities,
-                firstMatch: []
+                firstMatch: [{}]
               }
             }
           else

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -72,10 +72,10 @@ module Appium
           response = execute(:new_session, {}, merged_capabilities(desired_capabilities, w3c))
 
           @session_id = response['sessionId']
-          oss_status = response['status']
+          oss_status = response['status'] # for compatibility with Appium 1.7.1-
           value = response['value']
 
-          if value.is_a?(Hash)
+          if value.is_a?(Hash) # include for W3C format
             @session_id = value['sessionId'] if value.key?('sessionId')
 
             if value.key?('capabilities')

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -125,15 +125,15 @@ module Appium
             w3c_capabilities = ::Selenium::WebDriver::Remote::W3C::Capabilities.from_oss(new_caps)
 
             {
-                desiredCapabilities: desired_capabilities,
-                capabilities: {
-                    alwaysMatch: w3c_capabilities,
-                    firstMatch: []
-                }
+              desiredCapabilities: desired_capabilities,
+              capabilities: {
+                alwaysMatch: w3c_capabilities,
+                firstMatch: []
+              }
             }
           else
             {
-                desiredCapabilities: desired_capabilities
+              desiredCapabilities: desired_capabilities
             }
           end
         end

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -2,6 +2,9 @@ module Appium
   module Core
     class Base
       class Bridge < ::Selenium::WebDriver::Remote::Bridge
+        # Prefix for extra capability defined by W3C
+        APPIUM_PREFIX = 'appium:'.freeze
+
         # Almost same as self.handshake in ::Selenium::WebDriver::Remote::Bridge
         #
         # Implements protocol handshake which:
@@ -35,6 +38,37 @@ module Appium
           end
         end
 
+        # Override
+        # Creates session handling both OSS and W3C dialects.
+        # Copy from Selenium::WebDriver::Remote::Bridge to keep using `merged_capabilities` for Appium
+        #
+        # @param [::Selenium::WebDriver::Remote::W3C::Capabilities, Hash] capabilities A capability
+        # @return [::Selenium::WebDriver::Remote::Capabilities, ::Selenium::WebDriver::Remote::W3C::Capabilities]
+        #
+        def create_session(desired_capabilities)
+          response = execute(:new_session, {}, merged_capabilities(desired_capabilities))
+
+          @session_id = response['sessionId']
+          oss_status = response['status']
+          value = response['value']
+
+          if value.is_a?(Hash)
+            @session_id = value['sessionId'] if value.key?('sessionId')
+
+            if value.key?('capabilities')
+              value = value['capabilities']
+            elsif value.key?('value')
+              value = value['value']
+            end
+          end
+
+          unless @session_id
+            raise Error::WebDriverError, 'no sessionId in returned payload'
+          end
+
+          json_create(oss_status, value)
+        end
+
         # Append `appium:` prefix for Appium following W3C spec
         # https://www.w3.org/TR/webdriver/#dfn-validate-capabilities
         #
@@ -49,7 +83,7 @@ module Appium
             next if value.is_a?(String) && value.empty?
 
             capability_name = name.to_s
-            w3c_name = appium_prefix?(capability_name, w3c_capabilities) ? name : "appium:#{capability_name}"
+            w3c_name = appium_prefix?(capability_name, w3c_capabilities) ? name : "#{APPIUM_PREFIX}#{capability_name}"
 
             w3c_capabilities[w3c_name] = value
           end
@@ -59,7 +93,6 @@ module Appium
 
         private
 
-        APPIUM_PREFIX = 'appium:'.freeze
         def appium_prefix?(capability_name, w3c_capabilities)
           snake_cased_capability_names = ::Selenium::WebDriver::Remote::W3C::Capabilities::KNOWN.map(&:to_s)
           camel_cased_capability_names = snake_cased_capability_names.map(&w3c_capabilities.method(:camel_case))
@@ -69,7 +102,18 @@ module Appium
             capability_name.start_with?(APPIUM_PREFIX)
         end
 
-        # Use capabilities directory because Appium's capability is based on W3C one.
+        def json_create(oss_status, value)
+          if oss_status
+            ::Selenium::WebDriver.logger.info 'Detected OSS dialect.'
+            @dialect = :oss
+            ::Selenium::WebDriver::Remote::Capabilities.json_create(value)
+          else
+            ::Selenium::WebDriver.logger.info 'Detected W3C dialect.'
+            @dialect = :w3c
+            ::Selenium::WebDriver::Remote::W3C::Capabilities.json_create(value)
+          end
+        end
+
         # Called in bridge.create_session(desired_capabilities) from Parent class
         def merged_capabilities(desired_capabilities)
           new_caps = add_appium_prefix(desired_capabilities)

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -42,7 +42,7 @@ module Appium
         # Creates session handling both OSS and W3C dialects.
         # Copy from Selenium::WebDriver::Remote::Bridge to keep using `merged_capabilities` for Appium
         #
-        # If `desired_capabilities` has `w3c: true` capability, the bridge works as W3C client only for Appium 1.7.2-beta5+.
+        # If `desired_capabilities` has `w3c: true` capability, this bridge works with W3C protocol and it requires Appium 1.7.2-beta5+. Read an example.
         #
         # @param [::Selenium::WebDriver::Remote::W3C::Capabilities, Hash] capabilities A capability
         # @return [::Selenium::WebDriver::Remote::Capabilities, ::Selenium::WebDriver::Remote::W3C::Capabilities]

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -86,9 +86,7 @@ module Appium
         #   driver = core.start_driver #=> driver.dialect == :w3c if the Appium server support W3C.
         #
         def create_session(desired_capabilities)
-          force_mjsonwp = desired_capabilities.delete(:forceMjsonwp) || false
-
-          response = execute(:new_session, {}, merged_capabilities(desired_capabilities, force_mjsonwp))
+          response = execute(:new_session, {}, merged_capabilities(desired_capabilities))
 
           @session_id = response['sessionId']
           oss_status = response['status'] # for compatibility with Appium 1.7.1-
@@ -156,7 +154,25 @@ module Appium
           end
         end
 
-        def merged_capabilities(desired_capabilities, force_mjsonwp)
+        def delete_force_mjsonwp(capabilities)
+          w3c_capabilities = ::Selenium::WebDriver::Remote::W3C::Capabilities.new
+
+          capabilities = capabilities.__send__(:capabilities) unless capabilities.is_a?(Hash)
+          capabilities.each do |name, value|
+            next if value.nil?
+            next if value.is_a?(String) && value.empty?
+            next if name == :forceMjsonwp
+
+            w3c_capabilities[name] = value
+          end
+
+          w3c_capabilities
+        end
+
+        def merged_capabilities(desired_capabilities)
+          force_mjsonwp = desired_capabilities[:forceMjsonwp]
+          desired_capabilities = delete_force_mjsonwp(desired_capabilities) unless force_mjsonwp.nil?
+
           if force_mjsonwp
             {
               desiredCapabilities: desired_capabilities

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -156,8 +156,7 @@ module Appium
           end
         end
 
-        # Called in bridge.create_session(desired_capabilities) from Parent class
-        def merged_capabilities(desired_capabilities, force_mjsonwp = true)
+        def merged_capabilities(desired_capabilities, force_mjsonwp)
           if force_mjsonwp
             {
               desiredCapabilities: desired_capabilities

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -42,8 +42,8 @@ module Appium
         # Creates session handling both OSS and W3C dialects.
         # Copy from Selenium::WebDriver::Remote::Bridge to keep using `merged_capabilities` for Appium
         #
-        # If `desired_capabilities` has `force_mjsonwp: true` in the capability, this bridge works with mjsonwp protocol.
-        # If `force_mjsonwp: false` or no the capability, it depends on server side whether this bridge works as w3c or mjsonwp.
+        # If `desired_capabilities` has `forceMjsonwp: true` in the capability, this bridge works with mjsonwp protocol.
+        # If `forceMjsonwp: false` or no the capability, it depends on server side whether this bridge works as w3c or mjsonwp.
         #
         # @param [::Selenium::WebDriver::Remote::W3C::Capabilities, Hash] capabilities A capability
         # @return [::Selenium::WebDriver::Remote::Capabilities, ::Selenium::WebDriver::Remote::W3C::Capabilities]
@@ -58,7 +58,7 @@ module Appium
         #       platformVersion: '10.3',
         #       deviceName: 'iPhone Simulator',
         #       useNewWDA: true,
-        #       force_mjsonwp: true
+        #       forceMjsonwp: true
         #     },
         #     appium_lib: {
         #       wait: 30
@@ -86,7 +86,7 @@ module Appium
         #   driver = core.start_driver #=> driver.dialect == :w3c if the Appium server support W3C.
         #
         def create_session(desired_capabilities)
-          force_mjsonwp = desired_capabilities[:force_mjsonwp] || false
+          force_mjsonwp = desired_capabilities.delete(:forceMjsonwp) || false
 
           response = execute(:new_session, {}, merged_capabilities(desired_capabilities, force_mjsonwp))
 

--- a/test/functional/android/android/create_session_test.rb
+++ b/test/functional/android/android/create_session_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class AppiumLibCoreTest
   module WebDriver
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
-      def test_MJSONWP
+      def test_mjsonwp
         caps = Caps::ANDROID_OPS
         caps[:caps][:w3c] = false
         core = ::Appium::Core.for(self, caps)
@@ -15,7 +15,7 @@ class AppiumLibCoreTest
       end
 
       # Require Appium 1.7.2+
-      def test_W3C
+      def test_w3c
         caps = Caps::ANDROID_OPS
         caps[:caps][:w3c] = true
         core = ::Appium::Core.for(self, caps)

--- a/test/functional/android/android/create_session_test.rb
+++ b/test/functional/android/android/create_session_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
         caps = Caps::ANDROID_OPS
-        caps[:caps][:w3c] = false
+        caps[:caps][:force_mjsonwp] = false
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver
@@ -17,7 +17,7 @@ class AppiumLibCoreTest
       # Require Appium 1.7.2+
       def test_w3c
         caps = Caps::ANDROID_OPS
-        caps[:caps][:w3c] = true
+        caps[:caps][:force_mjsonwp] = true
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver

--- a/test/functional/android/android/create_session_test.rb
+++ b/test/functional/android/android/create_session_test.rb
@@ -5,24 +5,42 @@ class AppiumLibCoreTest
   module WebDriver
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
-        caps = Caps::ANDROID_OPS
-        caps[:caps][:forceMjsonwp] = false
-        core = ::Appium::Core.for(self, caps)
+        caps = Caps::ANDROID_OPS[:caps].merge({forceMjsonwp: true})
+        new_caps = Caps::ANDROID_OPS.merge({caps: caps})
+        core = ::Appium::Core.for(self, new_caps)
 
         driver = core.start_driver
 
         assert_equal :oss, driver.dialect
+        assert driver.capabilities[:forceMjsonwp].nil?
+        assert driver.capabilities['forceMjsonwp'].nil?
       end
 
       # Require Appium 1.7.2+
       def test_w3c
+        caps = Caps::ANDROID_OPS[:caps].merge({forceMjsonwp: false})
+        new_caps = Caps::ANDROID_OPS.merge({caps: caps})
+        core = ::Appium::Core.for(self, new_caps)
+
+        driver = core.start_driver
+
+        assert_equal :w3c, driver.dialect
+        assert driver.capabilities[:forceMjsonwp].nil?
+        assert driver.capabilities['forceMjsonwp'].nil?
+      end
+
+      # Require Appium 1.7.2+
+      def test_w3c_default
         caps = Caps::ANDROID_OPS
-        caps[:caps][:forceMjsonwp] = true
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver
 
         assert_equal :w3c, driver.dialect
+        assert driver.capabilities[:forceMjsonwp].nil?
+        assert driver.capabilities['forceMjsonwp'].nil?
+
+        driver.quit
       end
     end
   end

--- a/test/functional/android/android/create_session_test.rb
+++ b/test/functional/android/android/create_session_test.rb
@@ -5,8 +5,8 @@ class AppiumLibCoreTest
   module WebDriver
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
-        caps = Caps::ANDROID_OPS[:caps].merge({forceMjsonwp: true})
-        new_caps = Caps::ANDROID_OPS.merge({caps: caps})
+        caps = Caps::ANDROID_OPS[:caps].merge({ forceMjsonwp: true })
+        new_caps = Caps::ANDROID_OPS.merge({ caps: caps })
         core = ::Appium::Core.for(self, new_caps)
 
         driver = core.start_driver
@@ -18,8 +18,8 @@ class AppiumLibCoreTest
 
       # Require Appium 1.7.2+
       def test_w3c
-        caps = Caps::ANDROID_OPS[:caps].merge({forceMjsonwp: false})
-        new_caps = Caps::ANDROID_OPS.merge({caps: caps})
+        caps = Caps::ANDROID_OPS[:caps].merge({ forceMjsonwp: false })
+        new_caps = Caps::ANDROID_OPS.merge({ caps: caps })
         core = ::Appium::Core.for(self, new_caps)
 
         driver = core.start_driver

--- a/test/functional/android/android/create_session_test.rb
+++ b/test/functional/android/android/create_session_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+# $ rake test:func:android TEST=test/functional/android/webdriver/create_session_test.rb
+class AppiumLibCoreTest
+  module WebDriver
+    class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
+      def test_MJSONWP
+        caps = Caps::ANDROID_OPS
+        caps[:caps][:w3c] = false
+        core = ::Appium::Core.for(self, caps)
+
+        driver = core.start_driver
+
+        assert_equal :oss, driver.dialect
+      end
+
+      # Require Appium 1.7.2+
+      def test_W3C
+        caps = Caps::ANDROID_OPS
+        caps[:caps][:w3c] = true
+        core = ::Appium::Core.for(self, caps)
+
+        driver = core.start_driver
+
+        assert_equal :w3c, driver.dialect
+      end
+    end
+  end
+end

--- a/test/functional/android/android/create_session_test.rb
+++ b/test/functional/android/android/create_session_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
         caps = Caps::ANDROID_OPS
-        caps[:caps][:force_mjsonwp] = false
+        caps[:caps][:forceMjsonwp] = false
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver
@@ -17,7 +17,7 @@ class AppiumLibCoreTest
       # Require Appium 1.7.2+
       def test_w3c
         caps = Caps::ANDROID_OPS
-        caps[:caps][:force_mjsonwp] = true
+        caps[:caps][:forceMjsonwp] = true
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
         caps = Caps::IOS_OPS
-        caps[:caps][:force_mjsonwp] = true
+        caps[:caps][:forceMjsonwp] = true
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver
@@ -17,7 +17,17 @@ class AppiumLibCoreTest
       # Require Appium 1.7.2+
       def test_w3c
         caps = Caps::IOS_OPS
-        caps[:caps][:force_mjsonwp] = false
+        caps[:caps][:forceMjsonwp] = false
+        core = ::Appium::Core.for(self, caps)
+
+        driver = core.start_driver
+
+        assert_equal :w3c, driver.dialect
+      end
+
+      # Require Appium 1.7.2+
+      def test_w3c_default
+        caps = Caps::IOS_OPS
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class AppiumLibCoreTest
   module WebDriver
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
-      def test_MJSONWP
+      def test_mjsonwp
         caps = Caps::IOS_OPS
         caps[:caps][:w3c] = false
         core = ::Appium::Core.for(self, caps)
@@ -15,7 +15,7 @@ class AppiumLibCoreTest
       end
 
       # Require Appium 1.7.2+
-      def test_W3C
+      def test_w3c
         caps = Caps::IOS_OPS
         caps[:caps][:w3c] = true
         core = ::Appium::Core.for(self, caps)

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -5,24 +5,28 @@ class AppiumLibCoreTest
   module WebDriver
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
-        caps = Caps::IOS_OPS
-        caps[:caps][:forceMjsonwp] = true
-        core = ::Appium::Core.for(self, caps)
+        caps = Caps::IOS_OPS[:caps].merge({forceMjsonwp: true})
+        new_caps = Caps::IOS_OPS.merge({caps: caps})
+        core = ::Appium::Core.for(self, new_caps)
 
         driver = core.start_driver
 
         assert_equal :oss, driver.dialect
+        assert driver.capabilities[:forceMjsonwp].nil?
+        assert driver.capabilities['forceMjsonwp'].nil?
       end
 
       # Require Appium 1.7.2+
       def test_w3c
-        caps = Caps::IOS_OPS
-        caps[:caps][:forceMjsonwp] = false
-        core = ::Appium::Core.for(self, caps)
+        caps = Caps::IOS_OPS[:caps].merge({forceMjsonwp: false})
+        new_caps = Caps::IOS_OPS.merge({caps: caps})
+        core = ::Appium::Core.for(self, new_caps)
 
         driver = core.start_driver
 
         assert_equal :w3c, driver.dialect
+        assert driver.capabilities[:forceMjsonwp].nil?
+        assert driver.capabilities['forceMjsonwp'].nil?
       end
 
       # Require Appium 1.7.2+
@@ -33,6 +37,8 @@ class AppiumLibCoreTest
         driver = core.start_driver
 
         assert_equal :w3c, driver.dialect
+        assert driver.capabilities[:forceMjsonwp].nil?
+        assert driver.capabilities['forceMjsonwp'].nil?
       end
     end
   end

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
         caps = Caps::IOS_OPS
-        caps[:caps][:w3c] = false
+        caps[:caps][:force_mjsonwp] = true
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver
@@ -17,7 +17,7 @@ class AppiumLibCoreTest
       # Require Appium 1.7.2+
       def test_w3c
         caps = Caps::IOS_OPS
-        caps[:caps][:w3c] = true
+        caps[:caps][:force_mjsonwp] = false
         core = ::Appium::Core.for(self, caps)
 
         driver = core.start_driver

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+# $ rake test:func:ios TEST=test/functional/ios/webdriver/create_session_test.rb
+class AppiumLibCoreTest
+  module WebDriver
+    class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
+      def test_MJSONWP
+        caps = Caps::IOS_OPS
+        caps[:caps][:w3c] = false
+        core = ::Appium::Core.for(self, caps)
+
+        driver = core.start_driver
+
+        assert_equal :oss, driver.dialect
+      end
+
+      # Require Appium 1.7.2+
+      def test_W3C
+        caps = Caps::IOS_OPS
+        caps[:caps][:w3c] = true
+        core = ::Appium::Core.for(self, caps)
+
+        driver = core.start_driver
+
+        assert_equal :w3c, driver.dialect
+      end
+    end
+  end
+end

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -5,8 +5,8 @@ class AppiumLibCoreTest
   module WebDriver
     class CreateSessionTestTest < AppiumLibCoreTest::Function::TestCase
       def test_mjsonwp
-        caps = Caps::IOS_OPS[:caps].merge({forceMjsonwp: true})
-        new_caps = Caps::IOS_OPS.merge({caps: caps})
+        caps = Caps::IOS_OPS[:caps].merge({ forceMjsonwp: true })
+        new_caps = Caps::IOS_OPS.merge({ caps: caps })
         core = ::Appium::Core.for(self, new_caps)
 
         driver = core.start_driver
@@ -18,8 +18,8 @@ class AppiumLibCoreTest
 
       # Require Appium 1.7.2+
       def test_w3c
-        caps = Caps::IOS_OPS[:caps].merge({forceMjsonwp: false})
-        new_caps = Caps::IOS_OPS.merge({caps: caps})
+        caps = Caps::IOS_OPS[:caps].merge({ forceMjsonwp: false })
+        new_caps = Caps::IOS_OPS.merge({ caps: caps })
         core = ::Appium::Core.for(self, new_caps)
 
         driver = core.start_driver


### PR DESCRIPTION
The change is https://github.com/appium/ruby_lib_core/commit/360ba58a01a1b5b8f6abb034a146508125a7f213

---

- [x] tests
- [x] docs and parameters for caps to keep compatibility for lower version