### PR TITLE
add clipboard api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Enhancements
 - Add a `bug_report` option in `start_recording_screen`, Android
+- Add clipboard apis [#69](https://github.com/appium/ruby_lib_core/pull/69)
 
 ### Bug fixes
 

--- a/lib/appium_lib_core.rb
+++ b/lib/appium_lib_core.rb
@@ -10,6 +10,7 @@ require_relative 'appium_lib_core/device/touch_actions'
 require_relative 'appium_lib_core/device/multi_touch'
 require_relative 'appium_lib_core/device/screen_record'
 require_relative 'appium_lib_core/device/app_state'
+require_relative 'appium_lib_core/device/clipboard_content_type'
 
 require_relative 'appium_lib_core/android'
 require_relative 'appium_lib_core/android_uiautomator2'

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -242,7 +242,8 @@ module Appium
 
               params = { contentType: content_type }
 
-              execute(:get_clipboard, {}, params)
+              data = execute(:get_clipboard, {}, params)
+              Base64.decode64 data
             end
           end
 

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -118,15 +118,25 @@ module Appium
       #    @driver.start_recording_screen video_size: '1280x720', time_limit: '180', bit_rate: '5000000'
       #
 
-      # @!method set_clipboard(content:, content_type:, label:)
+      # @!method get_clipboard(content_type: :plaintext)
       #   Set the content of device's clipboard.
-      # @param [String] label: clipboard data label.
       # @param [String] content_type: one of supported content types.
-      # @param [String] content: base64-encoded content to be set.
+      # @return [String]
       #
       # @example
       #
-      #   @driver.get_performance_data package_name: package_name, data_type: data_type, data_read_timeout: 2
+      #   @driver.get_clipboard #=> "happy testing"
+      #
+
+      # @!method set_clipboard(content:, content_type: :plaintext, label: nil)
+      #   Set the content of device's clipboard.
+      # @param [String] label: clipboard data label.
+      # @param [String] content_type: one of supported content types.
+      # @param [String] content: Contents to be set. (Will encode with base64-encoded inside this method)
+      #
+      # @example
+      #
+      #   @driver.set_clipboard(content: 'happy testing') #=> {"protocol"=>"W3C"}
       #
 
       ####
@@ -226,7 +236,10 @@ module Appium
         def add_clipboard
           ::Appium::Core::Device.add_endpoint_method(:get_clipboard) do
             def get_clipboard(content_type: :plaintext)
-              raise 'content_type should be [:plaintext, :image, :url]' unless [:plaintext, :image, :url].member?(content_type)
+              unless ::Appium::Core::Device::Clipboard::CONTENT_TYPE.member?(content_type)
+                raise "content_type should be #{::Appium::Core::Device::Clipboard::CONTENT_TYPE}"
+              end
+
               params = { contentType: content_type }
 
               execute(:get_clipboard, {}, params)
@@ -235,7 +248,9 @@ module Appium
 
           ::Appium::Core::Device.add_endpoint_method(:set_clipboard) do
             def set_clipboard(content:, content_type: :plaintext, label: nil)
-              raise 'content_type should be [:plaintext, :image, :url]' unless [:plaintext, :image, :url].member?(content_type)
+              unless ::Appium::Core::Device::Clipboard::CONTENT_TYPE.member?(content_type)
+                raise "content_type should be #{::Appium::Core::Device::Clipboard::CONTENT_TYPE}"
+              end
 
               params = {
                 contentType: content_type,

--- a/lib/appium_lib_core/common/command.rb
+++ b/lib/appium_lib_core/common/command.rb
@@ -56,6 +56,8 @@ module Appium
         push_file:                  [:post, 'session/:session_id/appium/device/push_file'.freeze],
         pull_file:                  [:post, 'session/:session_id/appium/device/pull_file'.freeze],
         pull_folder:                [:post, 'session/:session_id/appium/device/pull_folder'.freeze],
+        get_clipboard:              [:post, 'session/:session_id/appium/device/get_clipboard'.freeze],
+        set_clipboard:              [:post, 'session/:session_id/appium/device/set_clipboard'.freeze],
         get_settings:               [:get,  'session/:session_id/appium/settings'.freeze],
         update_settings:            [:post, 'session/:session_id/appium/settings'.freeze],
         touch_actions:              [:post, 'session/:session_id/touch/perform'.freeze],

--- a/lib/appium_lib_core/common/device.rb
+++ b/lib/appium_lib_core/common/device.rb
@@ -657,6 +657,7 @@ module Appium
           add_handling_context
           add_screen_recording
           add_app_management
+          add_clipboard
         end
 
         # def extended
@@ -909,6 +910,27 @@ module Appium
             def stop_and_save_recording_screen(file_path)
               base64data = execute(:stop_recording_screen, {}, {})
               File.open(file_path, 'wb') { |f| f << Base64.decode64(base64data) }
+            end
+          end
+        end
+
+        def add_clipboard
+          add_endpoint_method(:get_clipboard) do
+            def get_clipboard(content_type: nil)
+              params = {}
+              params[:contentType] = content_type unless content_type.nil?
+
+              execute(:get_clipboard, {}, params)
+            end
+          end
+
+          add_endpoint_method(:set_clipboard) do
+            def set_clipboard(content:, content_type: nil, label: nil)
+              params = { content: content }
+              params[:contentType] = content_type unless content_type.nil?
+              params[:label] = label unless label.nil?
+
+              execute(:get_clipboard, {}, params)
             end
           end
         end

--- a/lib/appium_lib_core/common/device.rb
+++ b/lib/appium_lib_core/common/device.rb
@@ -657,7 +657,6 @@ module Appium
           add_handling_context
           add_screen_recording
           add_app_management
-          add_clipboard
         end
 
         # def extended
@@ -910,27 +909,6 @@ module Appium
             def stop_and_save_recording_screen(file_path)
               base64data = execute(:stop_recording_screen, {}, {})
               File.open(file_path, 'wb') { |f| f << Base64.decode64(base64data) }
-            end
-          end
-        end
-
-        def add_clipboard
-          add_endpoint_method(:get_clipboard) do
-            def get_clipboard(content_type: nil)
-              params = {}
-              params[:contentType] = content_type unless content_type.nil?
-
-              execute(:get_clipboard, {}, params)
-            end
-          end
-
-          add_endpoint_method(:set_clipboard) do
-            def set_clipboard(content:, content_type: nil, label: nil)
-              params = { content: content }
-              params[:contentType] = content_type unless content_type.nil?
-              params[:label] = label unless label.nil?
-
-              execute(:get_clipboard, {}, params)
             end
           end
         end

--- a/lib/appium_lib_core/device/clipboard_content_type.rb
+++ b/lib/appium_lib_core/device/clipboard_content_type.rb
@@ -1,0 +1,9 @@
+module Appium
+  module Core
+    module Device
+      module Clipboard
+        CONTENT_TYPE = [:plaintext, :image, :url].freeze
+      end
+    end
+  end
+end

--- a/lib/appium_lib_core/ios/device.rb
+++ b/lib/appium_lib_core/ios/device.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module Appium
   module Ios
     module Device
@@ -45,6 +47,37 @@ module Appium
           ::Appium::Core::Device.add_endpoint_method(:toggle_touch_id_enrollment) do
             def toggle_touch_id_enrollment(enabled = true)
               execute :toggle_touch_id_enrollment, {}, enabled: enabled
+            end
+          end
+
+          add_clipboard
+        end
+
+        private
+
+        def add_clipboard
+          ::Appium::Core::Device.add_endpoint_method(:get_clipboard) do
+            def get_clipboard(content_type: :plaintext)
+              raise 'content_type should be [:plaintext, :image, :url]' unless [:plaintext, :image, :url].member?(content_type)
+
+              params = {}
+              params[:contentType] = content_type
+
+              data = execute(:get_clipboard, {}, params)
+              Base64.decode64 data
+            end
+          end
+
+          ::Appium::Core::Device.add_endpoint_method(:set_clipboard) do
+            def set_clipboard(content:, content_type: :plaintext)
+              raise 'content_type should be [:plaintext, :image, :url]' unless [:plaintext, :image, :url].member?(content_type)
+
+              params = {
+                contentType: content_type,
+                content: Base64.encode64(content)
+              }
+
+              execute(:set_clipboard, {}, params)
             end
           end
         end

--- a/lib/appium_lib_core/ios/device.rb
+++ b/lib/appium_lib_core/ios/device.rb
@@ -30,6 +30,26 @@ module Appium
       #   @driver.toggle_touch_id_enrollment false #=> Disable toggle enrolled
       #
 
+      # @!method get_clipboard(content_type: :plaintext)
+      #   Set the content of device's clipboard.
+      # @param [String] content_type: one of supported content types.
+      # @return [String]
+      #
+      # @example
+      #
+      #   @driver.get_clipboard #=> "happy testing"
+      #
+
+      # @!method set_clipboard(content:, content_type: :plaintext)
+      #   Set the content of device's clipboard.
+      # @param [String] content_type: one of supported content types.
+      # @param [String] content: Contents to be set. (Will encode with base64-encoded inside this method)
+      #
+      # @example
+      #
+      #   @driver.set_clipboard(content: 'happy testing') #=> {"protocol"=>"W3C"}
+      #
+
       ####
       ## class << self
       ####
@@ -58,7 +78,9 @@ module Appium
         def add_clipboard
           ::Appium::Core::Device.add_endpoint_method(:get_clipboard) do
             def get_clipboard(content_type: :plaintext)
-              raise 'content_type should be [:plaintext, :image, :url]' unless [:plaintext, :image, :url].member?(content_type)
+              unless ::Appium::Core::Device::Clipboard::CONTENT_TYPE.member?(content_type)
+                raise "content_type should be #{::Appium::Core::Device::Clipboard::CONTENT_TYPE}"
+              end
 
               params = {}
               params[:contentType] = content_type
@@ -70,7 +92,9 @@ module Appium
 
           ::Appium::Core::Device.add_endpoint_method(:set_clipboard) do
             def set_clipboard(content:, content_type: :plaintext)
-              raise 'content_type should be [:plaintext, :image, :url]' unless [:plaintext, :image, :url].member?(content_type)
+              unless ::Appium::Core::Device::Clipboard::CONTENT_TYPE.member?(content_type)
+                raise "content_type should be #{::Appium::Core::Device::Clipboard::CONTENT_TYPE}"
+              end
 
               params = {
                 contentType: content_type,

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -337,6 +337,14 @@ class AppiumLibCoreTest
         assert !File.exist?(file.path)
       end
 
+      def test_clipbord
+        input = 'happy testing'
+
+        @@driver.set_clipboard(content: input, label: 'Note')
+
+        assert_equal input, @@driver.get_clipboard
+      end
+
       private
 
       def scroll_to(text)

--- a/test/functional/ios/ios/device_test.rb
+++ b/test/functional/ios/ios/device_test.rb
@@ -251,6 +251,14 @@ class AppiumLibCoreTest
         File.delete file.path
         assert !File.exist?(file.path)
       end
+
+      def test_clipbord
+        input = 'happy testing'
+
+        @@driver.set_clipboard(content: input)
+
+        assert_equal input, @@driver.get_clipboard
+      end
     end
   end
 end

--- a/test/unit/android/device_test.rb
+++ b/test/unit/android/device_test.rb
@@ -65,7 +65,9 @@ class AppiumLibCoreTest
                                             :start_activity,
                                             :end_coverage,
                                             :set_network_connection,
-                                            :get_performance_data])
+                                            :get_performance_data,
+                                            :get_clipboard,
+                                            :set_clipboard])
       end
 
       ## no args

--- a/test/unit/android/device_w3c_test.rb
+++ b/test/unit/android/device_w3c_test.rb
@@ -65,7 +65,9 @@ class AppiumLibCoreTest
                                             :start_activity,
                                             :end_coverage,
                                             :set_network_connection,
-                                            :get_performance_data])
+                                            :get_performance_data,
+                                            :get_clipboard,
+                                            :set_clipboard])
       end
 
       ## no args

--- a/test/unit/ios/device_test.rb
+++ b/test/unit/ios/device_test.rb
@@ -47,6 +47,8 @@ class AppiumLibCoreTest
                                             :push_file,
                                             :pull_file,
                                             :pull_folder,
+                                            :get_clipboard,
+                                            :set_clipboard,
                                             :get_settings,
                                             :update_settings,
                                             :touch_actions,

--- a/test/unit/ios/device_w3c_test.rb
+++ b/test/unit/ios/device_w3c_test.rb
@@ -47,6 +47,8 @@ class AppiumLibCoreTest
                                             :push_file,
                                             :pull_file,
                                             :pull_folder,
+                                            :get_clipboard,
+                                            :set_clipboard,
                                             :get_settings,
                                             :update_settings,
                                             :touch_actions,

--- a/test/unit/script/commands_test.rb
+++ b/test/unit/script/commands_test.rb
@@ -22,7 +22,7 @@ class ScriptTest
 
     # depends on webdriver-version... (number of commands)
     def test_implemented_mjsonwp_commands
-      assert_equal 142, @c.implemented_mjsonwp_commands.length
+      assert_equal 144, @c.implemented_mjsonwp_commands.length
       assert_equal ['session/:session_id/contexts', [:get]], @c.implemented_mjsonwp_commands.first
 
       # pick up an arbitrary command
@@ -30,7 +30,7 @@ class ScriptTest
     end
 
     def test_implemented_w3c_commands
-      assert_equal 113, @c.implemented_w3c_commands.length
+      assert_equal 115, @c.implemented_w3c_commands.length
       assert_equal ['session/:session_id/contexts', [:get]], @c.implemented_w3c_commands.first
 
       # pick up an arbitrary command
@@ -38,7 +38,7 @@ class ScriptTest
     end
 
     def test_implemented_core_commands
-      assert_equal 56, @c.implemented_core_commands.length
+      assert_equal 58, @c.implemented_core_commands.length
       assert_equal ['session/:session_id/contexts', [:get]], @c.implemented_core_commands.first
 
       # pick up an arbitrary command


### PR DESCRIPTION
https://github.com/appium/appium-base-driver/pull/199/files

## TODO
- [x] For Android
- [x] For iOS
- [ ] Append func test
    - And make sure they work
        - [x] iOS
        - [ ] Android
- [x] Add docstring
- [x] Update CHANGELOG

----

note: for android

```
java.lang.RuntimeException: Can't create handler inside thread that has not called Looper.prepare()
  at android.os.Handler.<init>(Handler.java:209)
  at android.os.Handler.<init>(Handler.java:123)
  at android.content.ClipboardManager$2.<init>(ClipboardManager.java:69)
  at android.content.ClipboardManager.<init>(ClipboardManager.java:69)
  at android.app.SystemServiceRegistry$12.createService(SystemServiceRegistry.java:276)
  at android.app.SystemServiceRegistry$12.createService(SystemServiceRegistry.java:275)
  at android.app.SystemServiceRegistry$CachedServiceFetcher.getService(SystemServiceRegistry.java:884)
  at android.app.SystemServiceRegistry.getSystemService(SystemServiceRegistry.java:837)
  at android.app.ContextImpl.getSystemService(ContextImpl.java:1370)
  at io.appium.uiautomator2.utils.ClipboardHelper.getManager(ClipboardHelper.java:37)
  at io.appium.uiautomator2.utils.ClipboardHelper.getTextData(ClipboardHelper.java:45)
  at io.appium.uiautomator2.handler.GetClipboard.safeHandle(GetClipboard.java:61)
  at io.appium.uiautomator2.handler.request.SafeRequestHandler.handle(SafeRequestHandler.java:56)
  at io.appium.uiautomator2.server.AppiumServlet.handleRequest(AppiumServlet.java:238)
  at io.appium.uiautomator2.server.AppiumServlet.handleHttpRequest(AppiumServlet.java:229)
  at io.appium.uiautomator2.http.ServerHandler.channelRead(ServerHandler.java:44)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
  at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
  at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:435)
  at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293)
  at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267)
  at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:250)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:345)
  at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1294)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:366)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:352)
  at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:911)
  at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:131)
  at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:611)
  at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:514)
  at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:468)
  at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:438)
  at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:140)
  at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.jav
```

note: for iOS
- Work with the latest WDA (Appium fork)