### PR TITLE
remove overrided action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Enhancements
+- Remove `touch` action by default and following `selenium-webdriver` in W3C action.
+    - Since XCUITest and UA2 drivers force handling the pointer as `touch`.
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/common/base/bridge/w3c.rb
+++ b/lib/appium_lib_core/common/base/bridge/w3c.rb
@@ -17,9 +17,8 @@ module Appium
           # - https://seleniumhq.github.io/selenium/docs/api/rb/Selenium/WebDriver/PointerActions.html
           # - https://seleniumhq.github.io/selenium/docs/api/rb/Selenium/WebDriver/KeyActions.html
           #
-          # @private
-          # For Appium
-          # override
+          # 'mouse' action is by default in the Ruby client. Appium server force the `mouse` action to `touch` once in
+          # the server side. So we don't consider the case.
           #
           # @example
           #
@@ -28,14 +27,9 @@ module Appium
           #
           #     # You can change the kind as the below.
           #     @driver.action(kind: :mouse).click(element).perform # The `click` is a part of `PointerActions`
-          def action(async: false, kind: :touch)
-            ::Selenium::WebDriver::W3CActionBuilder.new self,
-                                                        ::Selenium::WebDriver::Interactions.pointer(kind, name: kind.to_s),
-                                                        ::Selenium::WebDriver::Interactions.key('keyboard'),
-                                                        async
-          end
-          alias actions action
+          #
 
+          # Port from MJSONWP
           def get_timeouts
             execute :get_timeouts
           end

--- a/test/functional/ios/webdriver/w3c_actions_test.rb
+++ b/test/functional/ios/webdriver/w3c_actions_test.rb
@@ -21,10 +21,8 @@ class AppiumLibCoreTest
         @@driver.action.click(el).perform
 
         el = @@core.wait { @@driver.find_element(:name, 'Button with Image') }
-        @@driver.action.click_and_hold(el).move_to_location(0, 700).release.perform
-
-        el = @@core.wait { @@driver.find_element(:accessibility_id, 'ImageButton') }
-        assert_equal 'ImageButton', el.name
+        rect = el.rect
+        @@driver.action.click_and_hold(el).move_to_location(rect.x, rect.y + 500).release.perform
       end
     end
   end


### PR DESCRIPTION
We can see the diff:

```

[debug] [XCUITest] Received the following W3C actions: [
[debug] [XCUITest]   {
[debug] [XCUITest]     "type": "pointer",
[debug] [XCUITest]     "id": "mouse",
[debug] [XCUITest]     "actions": [ ... ],
[debug] [XCUITest]     "parameters": {
[debug] [XCUITest]       "pointerType": "mouse"
[debug] [XCUITest]     }
[debug] [XCUITest]   }
[debug] [XCUITest] ]
[debug] [XCUITest] Preprocessed actions: [
[debug] [XCUITest]   {
[debug] [XCUITest]     "type": "pointer",
[debug] [XCUITest]     "id": "mouse",
[debug] [XCUITest]     "actions": [ ... ],
[debug] [XCUITest]     "parameters": {
[debug] [XCUITest]       "pointerType": "touch" # Work as 'touch'
[debug] [XCUITest]     }
[debug] [XCUITest]   }
[debug] [XCUITest] ]
```

----

full

```
[debug] [XCUITest] Executing command 'performActions'
[debug] [XCUITest] Received the following W3C actions: [
[debug] [XCUITest]   {
[debug] [XCUITest]     "type": "pointer",
[debug] [XCUITest]     "id": "mouse",
[debug] [XCUITest]     "actions": [
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerMove",
[debug] [XCUITest]         "duration": 50,
[debug] [XCUITest]         "x": 0,
[debug] [XCUITest]         "y": 0,
[debug] [XCUITest]         "origin": {
[debug] [XCUITest]           "element-6066-11e4-a52e-4f735466cecf": "72000000-0000-0000-491F-000000000000"
[debug] [XCUITest]         }
[debug] [XCUITest]       },
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerDown",
[debug] [XCUITest]         "button": 0
[debug] [XCUITest]       },
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerMove",
[debug] [XCUITest]         "duration": 50,
[debug] [XCUITest]         "x": 17,
[debug] [XCUITest]         "y": 818,
[debug] [XCUITest]         "origin": "viewport"
[debug] [XCUITest]       },
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerUp",
[debug] [XCUITest]         "button": 0
[debug] [XCUITest]       }
[debug] [XCUITest]     ],
[debug] [XCUITest]     "parameters": {
[debug] [XCUITest]       "pointerType": "mouse"
[debug] [XCUITest]     }
[debug] [XCUITest]   }
[debug] [XCUITest] ]
[debug] [XCUITest] Preprocessed actions: [
[debug] [XCUITest]   {
[debug] [XCUITest]     "type": "pointer",
[debug] [XCUITest]     "id": "mouse",
[debug] [XCUITest]     "actions": [
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerMove",
[debug] [XCUITest]         "duration": 50,
[debug] [XCUITest]         "x": 0,
[debug] [XCUITest]         "y": 0,
[debug] [XCUITest]         "origin": {
[debug] [XCUITest]           "element-6066-11e4-a52e-4f735466cecf": "72000000-0000-0000-491F-000000000000"
[debug] [XCUITest]         }
[debug] [XCUITest]       },
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerDown",
[debug] [XCUITest]         "button": 0
[debug] [XCUITest]       },
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerMove",
[debug] [XCUITest]         "duration": 50,
[debug] [XCUITest]         "x": 17,
[debug] [XCUITest]         "y": 818,
[debug] [XCUITest]         "origin": "viewport"
[debug] [XCUITest]       },
[debug] [XCUITest]       {
[debug] [XCUITest]         "type": "pointerUp",
[debug] [XCUITest]         "button": 0
[debug] [XCUITest]       }
[debug] [XCUITest]     ],
[debug] [XCUITest]     "parameters": {
[debug] [XCUITest]       "pointerType": "touch" # Work as 'touch'
[debug] [XCUITest]     }
[debug] [XCUITest]   }
[debug] [XCUITest] ]
```