### PR TITLE
get ride of auto method generation to enhance ide support

### DIFF
--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -8,6 +8,106 @@ module Appium
 
       # rubocop:disable Metrics/LineLength
 
+      # @!method open_notifications
+      #   Open Android notifications
+      #
+      # @example
+      #
+      #   @driver.open_notifications
+      #
+
+      # @!method current_activity
+      # Get current activity name
+      # @return [String] An activity name
+      #
+      # @example
+      #
+      #   @driver.current_activity # '.ApiDemos'
+      #
+
+      # @!method current_package
+      # Get current package name
+      # @return [String] A package name
+      #
+      # @example
+      #
+      #   @driver.current_package # 'com.example.android.apis'
+      #
+
+      # @!method get_system_bars
+      # Get system bar's information
+      # @return [String]
+      #
+      # @example
+      #
+      #   @driver.get_system_bars
+      #
+
+      # @!method get_display_density
+      # Get connected device's density.
+      # @return [Integer] The size of density
+      #
+      # @example
+      #
+      #   @driver.get_display_density # 320
+      #
+
+      # @!method is_keyboard_shown
+      # Get whether keyboard is displayed or not.
+      # @return [Boolean] Return true if keyboard is shown. Return false if keyboard is hidden.
+      #
+      # @example
+      #   @driver.is_keyboard_shown # false
+      #
+
+      # @!method get_network_connection
+      #   Get the device network connection current status
+      #   See set_network_connection method for return value
+      #
+      # @example
+      #
+      #   @driver.network_connection_type #=> 6
+      #   @driver.get_network_connection  #=> 6
+      #
+
+      # @!method toggle_wifi
+      #   Switch the state of the wifi service only for Android
+      #
+      # @return [String]
+      #
+      # @example
+      #
+      #   @driver.toggle_wifi
+      #
+
+      # @!method toggle_data
+      #   Switch the state of data service only for Android, and the device should be rooted
+      #
+      # @return [String]
+      #
+      # @example
+      #
+      #   @driver.toggle_data
+      #
+
+      # @!method toggle_location_services
+      #   Switch the state of the location service
+      #
+      # @return [String]
+      #
+      # @example
+      #
+      #   @driver.toggle_location_services
+      #
+
+      # @!method toggle_airplane_mode
+      # Toggle flight mode on or off
+      #
+      # @example
+      #
+      #   @driver.toggle_airplane_mode
+      #
+
       # @!method hide_keyboard(close_key = nil, strategy = nil)
       # Hide the onscreen keyboard
       # @param [String] close_key The name of the key which closes the keyboard.
@@ -149,7 +249,79 @@ module Appium
         def extended(_mod)
           Appium::Core::Device.extend_webdriver_with_forwardable
 
-          # Android
+          Appium::Core::Device.add_endpoint_method(:open_notifications) do
+            def open_notifications
+              execute :open_notifications
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:toggle_airplane_mode) do
+            def toggle_airplane_mode
+              execute :toggle_airplane_mode
+            end
+            alias_method :toggle_flight_mode, :toggle_airplane_mode
+          end
+
+          Appium::Core::Device.add_endpoint_method(:current_activity) do
+            def current_activity
+              execute :current_activity
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:current_package) do
+            def current_package
+              execute :current_package
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:get_system_bars) do
+            def get_system_bars
+              execute :get_system_bars
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:get_display_density) do
+            def get_display_density
+              execute :get_display_density
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:is_keyboard_shown) do
+            def is_keyboard_shown # rubocop:disable Naming/PredicateName for compatibility
+              execute :is_keyboard_shown
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:get_network_connection) do
+            def get_network_connection
+              execute :get_network_connection
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:get_performance_data_types) do
+            def get_performance_data_types
+              execute :get_performance_data_types
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:toggle_wifi) do
+            def toggle_wifi
+              execute :toggle_wifi
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:toggle_data) do
+            def toggle_data
+              execute :toggle_data
+            end
+          end
+
+          Appium::Core::Device.add_endpoint_method(:toggle_location_services) do
+            def toggle_location_services
+              execute :toggle_location_services
+            end
+          end
+
           Appium::Core::Device.add_endpoint_method(:start_activity) do
             def start_activity(opts)
               raise 'opts must be a hash' unless opts.is_a? Hash

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -363,6 +363,11 @@ module Appium
 
           Appium::Core::Device.add_endpoint_method(:set_network_connection) do
             def set_network_connection(mode)
+              # TODO. Update set_network_connection as well
+              # connection_type = {airplane_mode: 1, wifi: 2, data: 4, all: 6, none: 0}
+              # raise ArgumentError, 'Invalid connection type' unless type_to_values.keys.include? mode
+              # type = connection_type[mode]
+              # execute :set_network_connection, {}, type: type
               execute :set_network_connection, {}, type: mode
             end
           end

--- a/lib/appium_lib_core/common/command.rb
+++ b/lib/appium_lib_core/common/command.rb
@@ -4,55 +4,41 @@ module Appium
   module Core
     # ref: https://github.com/appium/appium-base-driver/blob/master/lib/mjsonwp/routes.js
     module Commands
-      COMMAND_NO_ARG = {
-        # Common
-        shake:                      [:post, 'session/:session_id/appium/device/shake'.freeze],
-        launch_app:                 [:post, 'session/:session_id/appium/app/launch'.freeze],
-        close_app:                  [:post, 'session/:session_id/appium/app/close'.freeze],
-        reset:                      [:post, 'session/:session_id/appium/app/reset'.freeze],
-        device_locked?:             [:post, 'session/:session_id/appium/device/is_locked'.freeze],
-        unlock:                     [:post, 'session/:session_id/appium/device/unlock'.freeze],
-        device_time:                [:get,  'session/:session_id/appium/device/system_time'.freeze],
-        current_context:            [:get,  'session/:session_id/context'.freeze],
-
-        # Android
-        open_notifications:         [:post, 'session/:session_id/appium/device/open_notifications'.freeze],
-        toggle_airplane_mode:       [:post, 'session/:session_id/appium/device/toggle_airplane_mode'.freeze],
-        current_activity:           [:get,  'session/:session_id/appium/device/current_activity'.freeze],
-        current_package:            [:get,  'session/:session_id/appium/device/current_package'.freeze],
-        get_system_bars:            [:get,  'session/:session_id/appium/device/system_bars'.freeze],
-        get_display_density:        [:get,  'session/:session_id/appium/device/display_density'.freeze],
-        is_keyboard_shown:          [:get,  'session/:session_id/appium/device/is_keyboard_shown'.freeze],
-        get_network_connection:     [:get,  'session/:session_id/network_connection'.freeze], # defined also in OSS
-        get_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'.freeze],
-        toggle_wifi:                [:post, 'session/:session_id/appium/device/toggle_wifi'.freeze],
-        toggle_data:                [:post, 'session/:session_id/appium/device/toggle_data'.freeze],
-        toggle_location_services:   [:post, 'session/:session_id/appium/device/toggle_location_services'.freeze]
-
-        # iOS
-      }.freeze
-
       # Some commands differ for each driver.
       COMMAND = {
         # common
         available_contexts:         [:get,  'session/:session_id/contexts'.freeze],
         set_context:                [:post, 'session/:session_id/context'.freeze],
+        current_context:            [:get,  'session/:session_id/context'.freeze],
+
+        touch_actions:              [:post, 'session/:session_id/touch/perform'.freeze],
+        multi_touch:                [:post, 'session/:session_id/touch/multi/perform'.freeze],
+
+        set_immediate_value:        [:post, 'session/:session_id/appium/element/:id/value'.freeze],
+        replace_value:              [:post, 'session/:session_id/appium/element/:id/replace_value'.freeze],
+
+        launch_app:                 [:post, 'session/:session_id/appium/app/launch'.freeze],
+        close_app:                  [:post, 'session/:session_id/appium/app/close'.freeze],
+        reset:                      [:post, 'session/:session_id/appium/app/reset'.freeze],
+        background_app:             [:post, 'session/:session_id/appium/app/background'.freeze],
         app_strings:                [:post, 'session/:session_id/appium/app/strings'.freeze],
+
+        device_locked?:             [:post, 'session/:session_id/appium/device/is_locked'.freeze],
+        unlock:                     [:post, 'session/:session_id/appium/device/unlock'.freeze],
         lock:                       [:post, 'session/:session_id/appium/device/lock'.freeze],
+        device_time:                [:get,  'session/:session_id/appium/device/system_time'.freeze],
         install_app:                [:post, 'session/:session_id/appium/device/install_app'.freeze],
         remove_app:                 [:post, 'session/:session_id/appium/device/remove_app'.freeze],
         app_installed?:             [:post, 'session/:session_id/appium/device/app_installed'.freeze],
         activate_app:               [:post, 'session/:session_id/appium/device/activate_app'.freeze],
         terminate_app:              [:post, 'session/:session_id/appium/device/terminate_app'.freeze],
         app_state:                  [:post, 'session/:session_id/appium/device/app_state'.freeze],
-        background_app:             [:post, 'session/:session_id/appium/app/background'.freeze],
+        shake:                      [:post, 'session/:session_id/appium/device/shake'.freeze],
         hide_keyboard:              [:post, 'session/:session_id/appium/device/hide_keyboard'.freeze],
         press_keycode:              [:post, 'session/:session_id/appium/device/press_keycode'.freeze],
         long_press_keycode:         [:post, 'session/:session_id/appium/device/long_press_keycode'.freeze],
         # keyevent is only for Selendroid
         keyevent:                   [:post, 'session/:session_id/appium/device/keyevent'.freeze],
-        set_immediate_value:        [:post, 'session/:session_id/appium/element/:id/value'.freeze],
-        replace_value:              [:post, 'session/:session_id/appium/element/:id/replace_value'.freeze],
         push_file:                  [:post, 'session/:session_id/appium/device/push_file'.freeze],
         pull_file:                  [:post, 'session/:session_id/appium/device/pull_file'.freeze],
         pull_folder:                [:post, 'session/:session_id/appium/device/pull_folder'.freeze],
@@ -60,17 +46,27 @@ module Appium
         set_clipboard:              [:post, 'session/:session_id/appium/device/set_clipboard'.freeze],
         get_settings:               [:get,  'session/:session_id/appium/settings'.freeze],
         update_settings:            [:post, 'session/:session_id/appium/settings'.freeze],
-        touch_actions:              [:post, 'session/:session_id/touch/perform'.freeze],
-        multi_touch:                [:post, 'session/:session_id/touch/multi/perform'.freeze],
         stop_recording_screen:      [:post, 'session/:session_id/appium/stop_recording_screen'.freeze],
         start_recording_screen:     [:post, 'session/:session_id/appium/start_recording_screen'.freeze]
       }.freeze
 
       COMMAND_ANDROID = {
+        open_notifications:         [:post, 'session/:session_id/appium/device/open_notifications'.freeze],
+        toggle_airplane_mode:       [:post, 'session/:session_id/appium/device/toggle_airplane_mode'.freeze],
         start_activity:             [:post, 'session/:session_id/appium/device/start_activity'.freeze],
+        current_activity:           [:get,  'session/:session_id/appium/device/current_activity'.freeze],
+        current_package:            [:get,  'session/:session_id/appium/device/current_package'.freeze],
+        get_system_bars:            [:get,  'session/:session_id/appium/device/system_bars'.freeze],
+        get_display_density:        [:get,  'session/:session_id/appium/device/display_density'.freeze],
+        is_keyboard_shown:          [:get,  'session/:session_id/appium/device/is_keyboard_shown'.freeze],
+        toggle_wifi:                [:post, 'session/:session_id/appium/device/toggle_wifi'.freeze],
+        toggle_data:                [:post, 'session/:session_id/appium/device/toggle_data'.freeze],
+        toggle_location_services:   [:post, 'session/:session_id/appium/device/toggle_location_services'.freeze],
         end_coverage:               [:post, 'session/:session_id/appium/app/end_test_coverage'.freeze],
-        set_network_connection:     [:post, 'session/:session_id/network_connection'.freeze], # defined also in OSS
+        get_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'.freeze],
         get_performance_data:       [:post, 'session/:session_id/appium/getPerformanceData'.freeze],
+        get_network_connection:     [:get,  'session/:session_id/network_connection'.freeze], # defined also in OSS
+        set_network_connection:     [:post, 'session/:session_id/network_connection'.freeze], # defined also in OSS
 
         # only emulator
         send_sms:                   [:post, 'session/:session_id/appium/device/send_sms'.freeze],
@@ -87,8 +83,7 @@ module Appium
         toggle_touch_id_enrollment: [:post, 'session/:session_id/appium/simulator/toggle_touch_id_enrollment'.freeze]
       }.freeze
 
-      COMMANDS = {}.merge(COMMAND).merge(COMMAND_ANDROID).merge(COMMAND_IOS)
-                   .merge(COMMAND_NO_ARG).freeze
+      COMMANDS = {}.merge(COMMAND).merge(COMMAND_ANDROID).merge(COMMAND_IOS).freeze
 
       COMMANDS_EXTEND_MJSONWP = COMMANDS.merge(::Appium::Core::Base::Commands::OSS).merge(
         {

--- a/lib/appium_lib_core/common/device.rb
+++ b/lib/appium_lib_core/common/device.rb
@@ -433,13 +433,13 @@ module Appium
 
           add_endpoint_method(:shake) do
             def shake
-              execute(:shake)
+              execute :shake
             end
           end
 
           add_endpoint_method(:device_time) do
             def device_time
-              execute(:device_time)
+              execute :device_time
             end
           end
 
@@ -564,13 +564,13 @@ module Appium
 
           add_endpoint_method(:device_locked?) do
             def device_locked?
-              execute(:device_locked?)
+              execute :device_locked?
             end
           end
 
           add_endpoint_method(:unlock) do
             def unlock
-              execute(:unlock)
+              execute :unlock
             end
           end
         end
@@ -602,25 +602,25 @@ module Appium
         def add_app_management
           add_endpoint_method(:launch_app) do
             def launch_app
-              execute(:launch_app)
+              execute :launch_app
             end
           end
 
           add_endpoint_method(:close_app) do
             def close_app
-              execute(:close_app)
+              execute :close_app
             end
           end
 
           add_endpoint_method(:close_app) do
             def close_app
-              execute(:close_app)
+              execute :close_app
             end
           end
 
           add_endpoint_method(:reset) do
             def reset
-              execute(:reset)
+              execute :reset
             end
           end
 
@@ -830,7 +830,7 @@ module Appium
 
           add_endpoint_method(:current_context) do
             def current_context
-              execute(:current_context)
+              execute :current_context
             end
           end
 

--- a/lib/appium_lib_core/common/device.rb
+++ b/lib/appium_lib_core/common/device.rb
@@ -460,7 +460,7 @@ module Appium
 
               extension = File.extname(png_path).downcase
               if extension != '.png'
-                WebDriver.logger.warn 'name used for saved screenshot does not match file type. '\
+                ::Appium::Logger.warn 'name used for saved screenshot does not match file type. '\
                                 'It should end with .png extension'
               end
               File.open(png_path, 'wb') { |f| f << result.unpack('m')[0] }
@@ -497,7 +497,7 @@ module Appium
             def save_viewport_screenshot(png_path)
               extension = File.extname(png_path).downcase
               if extension != '.png'
-                WebDriver.logger.warn 'name used for saved screenshot does not match file type. '\
+                ::Appium::Logger.warn 'name used for saved screenshot does not match file type. '\
                                   'It should end with .png extension'
               end
               viewport_screenshot_encode64 = execute_script('mobile: viewportScreenshot')
@@ -711,17 +711,17 @@ module Appium
 
               case response
               when 0
-                Appium::Core::Device::AppState::NOT_INSTALLED
+                ::Appium::Core::Device::AppState::NOT_INSTALLED
               when 1
-                Appium::Core::Device::AppState::NOT_RUNNING
+                ::Appium::Core::Device::AppState::NOT_RUNNING
               when 2
-                Appium::Core::Device::AppState::RUNNING_IN_BACKGROUND_SUSPENDED
+                ::Appium::Core::Device::AppState::RUNNING_IN_BACKGROUND_SUSPENDED
               when 3
-                Appium::Core::Device::AppState::RUNNING_IN_BACKGROUND
+                ::Appium::Core::Device::AppState::RUNNING_IN_BACKGROUND
               when 4
-                Appium::Core::Device::AppState::RUNNING_IN_FOREGROUND
+                ::Appium::Core::Device::AppState::RUNNING_IN_FOREGROUND
               else
-                Appium::Logger.debug("Unexpected status in app_state: #{response}")
+                ::Appium::Logger.debug("Unexpected status in app_state: #{response}")
                 response
               end
             end

--- a/lib/appium_lib_core/common/device.rb
+++ b/lib/appium_lib_core/common/device.rb
@@ -11,50 +11,6 @@ module Appium
       ## No argument
       ####
 
-      # @!method current_activity
-      # Get current activity name
-      # @return [String] An activity name
-      #
-      # @example
-      #
-      #   @driver.current_activity # '.ApiDemos'
-      #
-
-      # @!method current_package
-      # Get current package name
-      # @return [String] A package name
-      #
-      # @example
-      #
-      #   @driver.current_package # 'com.example.android.apis'
-      #
-
-      # @!method get_system_bars
-      # Get system bar's information
-      # @return [String]
-      #
-      # @example
-      #
-      #   @driver.get_system_bars
-      #
-
-      # @!method get_display_density
-      # Get connected device's density.
-      # @return [Integer] The size of density
-      #
-      # @example
-      #
-      #   @driver.get_display_density # 320
-      #
-
-      # @!method is_keyboard_shown
-      # Get whether keyboard is displayed or not.
-      # @return [Boolean] Return true if keyboard is shown. Return false if keyboard is hidden.
-      #
-      # @example
-      #   @driver.is_keyboard_shown # false
-      #
-
       # @!method launch_app
       # Start the simulator and application configured with desired capabilities
       #
@@ -87,14 +43,6 @@ module Appium
       #   @driver.shake
       #
 
-      # @!method toggle_flight_mode
-      # Toggle flight mode on or off
-      #
-      # @example
-      #
-      #   @driver.toggle_flight_mode
-      #
-
       # @!method unlock
       # Unlock the device
       #
@@ -111,24 +59,6 @@ module Appium
       #   @driver.device_locked?
       #
 
-      # @!method get_network_connection
-      #   Get the device network connection current status
-      #   See set_network_connection method for return value
-      #
-      # @example
-      #
-      #   @driver.network_connection_type #=> 6
-      #   @driver.get_network_connection  #=> 6
-      #
-
-      # @!method open_notifications
-      #   Open Android notifications
-      #
-      # @example
-      #
-      #   @driver.open_notifications
-      #
-
       # @!method device_time
       #   Get the time on the device
       #
@@ -137,36 +67,6 @@ module Appium
       # @example
       #
       #   @driver.device_time
-      #
-
-      # @!method toggle_location_services
-      #   Switch the state of the location service
-      #
-      # @return [String]
-      #
-      # @example
-      #
-      #   @driver.toggle_location_services
-      #
-
-      # @!method toggle_wifi
-      #   Switch the state of the wifi service only for Android
-      #
-      # @return [String]
-      #
-      # @example
-      #
-      #   @driver.toggle_wifi
-      #
-
-      # @!method toggle_data
-      #   Switch the state of data service only for Android, and the device should be rooted
-      #
-      # @return [String]
-      #
-      # @example
-      #
-      #   @driver.toggle_data
       #
 
       ####
@@ -531,40 +431,15 @@ module Appium
         def extended(_mod)
           extend_webdriver_with_forwardable
 
-          ::Appium::Core::Commands::COMMAND_NO_ARG.each_key do |method|
-            add_endpoint_method method
-          end
-
-          add_endpoint_method(:available_contexts) do
-            def available_contexts
-              # return empty array instead of nil on failure
-              execute(:available_contexts, {}) || []
+          add_endpoint_method(:shake) do
+            def shake
+              execute(:shake)
             end
           end
 
-          add_endpoint_method(:app_strings) do
-            def app_strings(language = nil)
-              opts = language ? { language: language } : {}
-              execute :app_strings, {}, opts
-            end
-          end
-
-          add_endpoint_method(:lock) do
-            def lock(duration = nil)
-              opts = duration ? { seconds: duration } : {}
-              execute :lock, {}, opts
-            end
-          end
-
-          add_endpoint_method(:background_app) do
-            def background_app(duration = 0)
-              execute :background_app, {}, seconds: duration
-            end
-          end
-
-          add_endpoint_method(:set_context) do
-            def set_context(context = null)
-              execute :set_context, {}, name: context
+          add_endpoint_method(:device_time) do
+            def device_time
+              execute(:device_time)
             end
           end
 
@@ -606,27 +481,6 @@ module Appium
             end
           end
 
-          add_endpoint_method(:push_file) do
-            def push_file(path, filedata)
-              encoded_data = Base64.encode64 filedata
-              execute :push_file, {}, path: path, data: encoded_data
-            end
-          end
-
-          add_endpoint_method(:pull_file) do
-            def pull_file(path)
-              data = execute :pull_file, {}, path: path
-              Base64.decode64 data
-            end
-          end
-
-          add_endpoint_method(:pull_folder) do
-            def pull_folder(path)
-              data = execute :pull_folder, {}, path: path
-              Base64.decode64 data
-            end
-          end
-
           add_endpoint_method(:get_settings) do
             def get_settings
               execute :get_settings, {}
@@ -657,6 +511,8 @@ module Appium
           add_handling_context
           add_screen_recording
           add_app_management
+          add_device_lock
+          add_file_management
         end
 
         # def extended
@@ -698,8 +554,89 @@ module Appium
           end
         end
 
+        def add_device_lock
+          add_endpoint_method(:lock) do
+            def lock(duration = nil)
+              opts = duration ? { seconds: duration } : {}
+              execute :lock, {}, opts
+            end
+          end
+
+          add_endpoint_method(:device_locked?) do
+            def device_locked?
+              execute(:device_locked?)
+            end
+          end
+
+          add_endpoint_method(:unlock) do
+            def unlock
+              execute(:unlock)
+            end
+          end
+        end
+
+        def add_file_management
+          add_endpoint_method(:push_file) do
+            def push_file(path, filedata)
+              encoded_data = Base64.encode64 filedata
+              execute :push_file, {}, path: path, data: encoded_data
+            end
+          end
+
+          add_endpoint_method(:pull_file) do
+            def pull_file(path)
+              data = execute :pull_file, {}, path: path
+              Base64.decode64 data
+            end
+          end
+
+          add_endpoint_method(:pull_folder) do
+            def pull_folder(path)
+              data = execute :pull_folder, {}, path: path
+              Base64.decode64 data
+            end
+          end
+        end
+
         # rubocop:disable Metrics/ParameterLists,Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
         def add_app_management
+          add_endpoint_method(:launch_app) do
+            def launch_app
+              execute(:launch_app)
+            end
+          end
+
+          add_endpoint_method(:close_app) do
+            def close_app
+              execute(:close_app)
+            end
+          end
+
+          add_endpoint_method(:close_app) do
+            def close_app
+              execute(:close_app)
+            end
+          end
+
+          add_endpoint_method(:reset) do
+            def reset
+              execute(:reset)
+            end
+          end
+
+          add_endpoint_method(:app_strings) do
+            def app_strings(language = nil)
+              opts = language ? { language: language } : {}
+              execute :app_strings, {}, opts
+            end
+          end
+
+          add_endpoint_method(:background_app) do
+            def background_app(duration = 0)
+              execute :background_app, {}, seconds: duration
+            end
+          end
+
           add_endpoint_method(:install_app) do
             def install_app(path,
                             replace: nil,
@@ -888,6 +825,25 @@ module Appium
           add_endpoint_method(:switch_to_default_context) do
             def switch_to_default_context
               set_context nil
+            end
+          end
+
+          add_endpoint_method(:current_context) do
+            def current_context
+              execute(:current_context)
+            end
+          end
+
+          add_endpoint_method(:available_contexts) do
+            def available_contexts
+              # return empty array instead of nil on failure
+              execute(:available_contexts, {}) || []
+            end
+          end
+
+          add_endpoint_method(:set_context) do
+            def set_context(context = null)
+              execute :set_context, {}, name: context
             end
           end
         end

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
         @@driver ||= @@core.start_driver
 
         @@driver.start_activity app_package: 'io.appium.android.apis',
-                                app_activity: '.ApiDemos'
+                                app_activity: 'io.appium.android.apis.ApiDemos'
       end
 
       def teardown

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -11,9 +11,6 @@ class AppiumLibCoreTest
 
         @@driver.start_activity app_package: 'io.appium.android.apis',
                                 app_activity: '.ApiDemos'
-
-        require 'pry'
-        binding.pry
       end
 
       def teardown
@@ -170,10 +167,7 @@ class AppiumLibCoreTest
         assert_equal(true, @@driver.get_settings['ignoreUnimportantViews'])
 
         @@driver.update_settings('ignoreUnimportantViews' => false)
-
-        @@driver.update_settings('keyInjectionDelay' => true)
-
-
+        assert_equal(false, @@driver.get_settings['ignoreUnimportantViews'])
       end
 
       def test_touch_actions

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -11,6 +11,9 @@ class AppiumLibCoreTest
 
         @@driver.start_activity app_package: 'io.appium.android.apis',
                                 app_activity: '.ApiDemos'
+
+        require 'pry'
+        binding.pry
       end
 
       def teardown
@@ -159,6 +162,7 @@ class AppiumLibCoreTest
         assert data.length > 100
       end
 
+      # check
       def test_settings
         assert_equal(false, @@driver.get_settings['ignoreUnimportantViews'])
 
@@ -166,6 +170,10 @@ class AppiumLibCoreTest
         assert_equal(true, @@driver.get_settings['ignoreUnimportantViews'])
 
         @@driver.update_settings('ignoreUnimportantViews' => false)
+
+        @@driver.update_settings('keyInjectionDelay' => true)
+
+
       end
 
       def test_touch_actions

--- a/test/functional/android/driver_test.rb
+++ b/test/functional/android/driver_test.rb
@@ -17,7 +17,6 @@ class AppiumLibCoreTest
       v = @@core.appium_server_version
 
       refute_nil v['build']['version']
-      refute_nil v['build']['revision']
     end
 
     def test_platform_version

--- a/test/functional/android/patch_test.rb
+++ b/test/functional/android/patch_test.rb
@@ -9,7 +9,7 @@ class AppiumLibCoreTest
       @@driver ||= @@core.start_driver
 
       @@driver.start_activity app_package: 'io.appium.android.apis',
-                              app_activity: '.ApiDemos'
+                              app_activity: 'io.appium.android.apis.ApiDemos'
     end
 
     def teardown

--- a/test/functional/android/webdriver/device_test.rb
+++ b/test/functional/android/webdriver/device_test.rb
@@ -113,7 +113,8 @@ class AppiumLibCoreTest
         assert @@driver.get_network_connection
         assert @@driver.network_connection_type
         assert @@driver.set_network_connection(6)
-        assert @@driver.network_connection_type = :all # TODO: depends on selenium-webdriver. Test failed with webdriver 3.11.0 with a number.
+        # TODO: depends on selenium-webdriver. Test failed with webdriver 3.11.0 with a number.
+        assert @@driver.network_connection_type = :all
       end
 
       def test_session_capability

--- a/test/functional/android/webdriver/device_test.rb
+++ b/test/functional/android/webdriver/device_test.rb
@@ -48,17 +48,17 @@ class AppiumLibCoreTest
         assert s_source.include?('o.appium.android.apis')
       end
 
-      def test_location
-        latitude = 100
-        longitude = 100
-        altitude = 75
-        @@driver.set_location(latitude, longitude, altitude)
-
-        loc = @@driver.location # check the location
-        assert_equal 100, loc.latitude
-        assert_equal 100, loc.longitude
-        assert_equal 75, loc.altitude
-      end
+      # def test_location
+      #   latitude = 100
+      #   longitude = 100
+      #   altitude = 75
+      #   @@driver.set_location(latitude, longitude, altitude)
+      #
+      #   loc = @@driver.location # check the location
+      #   assert_equal 100, loc.latitude
+      #   assert_equal 100, loc.longitude
+      #   assert_equal 75, loc.altitude
+      # end
 
       def test_accept_alert
         @@core.wait { @@driver.find_element :accessibility_id, 'App' }.click
@@ -111,12 +111,12 @@ class AppiumLibCoreTest
       def test_network_connection
         assert @@driver.get_network_connection
         assert @@driver.network_connection_type
-        assert @driver.set_network_connection(6)
-        assert @driver.network_connection_type = 6
+        assert @@driver.set_network_connection(6)
+        assert @@driver.network_connection_type = 6
       end
 
       def test_session_capability
-        assert @driver.session_capabilities['deviceUDID'] == 'emulator-5554'
+        assert @@driver.session_capabilities['deviceUDID'] == 'emulator-5554'
       end
     end
   end

--- a/test/functional/android/webdriver/device_test.rb
+++ b/test/functional/android/webdriver/device_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
         @@driver ||= @@core.start_driver
 
         @@driver.start_activity app_package: 'io.appium.android.apis',
-                                app_activity: '.ApiDemos'
+                                app_activity: 'io.appium.android.apis.ApiDemos'
       end
 
       def teardown
@@ -112,7 +112,7 @@ class AppiumLibCoreTest
         assert @@driver.get_network_connection
         assert @@driver.network_connection_type
         assert @@driver.set_network_connection(6)
-        assert @@driver.network_connection_type = 6
+        assert @@driver.network_connection_type = :all # TODO: depends on selenium-webdriver. Test failed with webdriver 3.11.0 with a number.
       end
 
       def test_session_capability

--- a/test/functional/android/webdriver/device_test.rb
+++ b/test/functional/android/webdriver/device_test.rb
@@ -104,7 +104,8 @@ class AppiumLibCoreTest
       end
 
       def test_logs
-        assert_equal %i(syslog crashlog performance), @@driver.logs.available_types
+        # :logcat, :bugreport, :server in 1.7.2
+        assert_equal %i(logcat bugreport server), @@driver.logs.available_types
         assert @@driver.logs.get(:syslog)
       end
 

--- a/test/functional/android/webdriver/w3c_actions_test.rb
+++ b/test/functional/android/webdriver/w3c_actions_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
         @@driver ||= @@core.start_driver
 
         @@driver.start_activity app_package: 'io.appium.android.apis',
-                                app_activity: '.ApiDemos'
+                                app_activity: 'io.appium.android.apis.ApiDemos'
       end
 
       def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,7 +43,8 @@ class AppiumLibCoreTest
         deviceName: 'iPhone Simulator',
         useNewWDA: true,
         useJSONSource: true,
-        someCapability: 'some_capability'
+        someCapability: 'some_capability',
+        newCommandTimeout: 120
       },
       appium_lib: {
         export_session: true,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,7 +67,8 @@ class AppiumLibCoreTest
         appActivity: 'io.appium.android.apis.ApiDemos',
         someCapability: 'some_capability',
         unicodeKeyboard: true,
-        resetKeyboard: true
+        resetKeyboard: true,
+        newCommandTimeout: 300
       },
       appium_lib: {
         export_session: true,

--- a/test/unit/android/device_test.rb
+++ b/test/unit/android/device_test.rb
@@ -16,7 +16,7 @@ class AppiumLibCoreTest
         array.each { |v| assert ::Appium::Core::Base::Bridge::MJSONWP.method_defined?(v) }
       end
 
-      def test_no_arg_definitions
+      def test_with_arg_definitions
         parameterized_method_defined_check([:shake,
                                             :launch_app,
                                             :close_app,
@@ -33,11 +33,8 @@ class AppiumLibCoreTest
                                             :get_display_density,
                                             :is_keyboard_shown,
                                             :get_network_connection,
-                                            :get_performance_data_types])
-      end
-
-      def test_with_arg_definitions
-        parameterized_method_defined_check([:available_contexts,
+                                            :get_performance_data_types,
+                                            :available_contexts,
                                             :set_context,
                                             :app_strings,
                                             :lock,

--- a/test/unit/android/device_w3c_test.rb
+++ b/test/unit/android/device_w3c_test.rb
@@ -16,7 +16,7 @@ class AppiumLibCoreTest
         array.each { |v| assert ::Appium::Core::Base::Bridge::W3C.method_defined?(v) }
       end
 
-      def test_no_arg_definitions
+      def test_with_arg_definitions
         parameterized_method_defined_check([:shake,
                                             :launch_app,
                                             :close_app,
@@ -33,11 +33,8 @@ class AppiumLibCoreTest
                                             :get_display_density,
                                             :is_keyboard_shown,
                                             :get_network_connection,
-                                            :get_performance_data_types])
-      end
-
-      def test_with_arg_definitions
-        parameterized_method_defined_check([:available_contexts,
+                                            :get_performance_data_types,
+                                            :available_contexts,
                                             :set_context,
                                             :app_strings,
                                             :lock,

--- a/test/unit/ios/device_test.rb
+++ b/test/unit/ios/device_test.rb
@@ -16,7 +16,7 @@ class AppiumLibCoreTest
         array.each { |v| assert ::Appium::Core::Base::Bridge::MJSONWP.method_defined?(v) }
       end
 
-      def test_no_arg_definitions
+      def test_with_arg_definitions
         parameterized_method_defined_check([:shake,
                                             :launch_app,
                                             :close_app,
@@ -24,11 +24,8 @@ class AppiumLibCoreTest
                                             :device_locked?,
                                             :unlock,
                                             :device_time,
-                                            :current_context])
-      end
-
-      def test_with_arg_definitions
-        parameterized_method_defined_check([:available_contexts,
+                                            :current_context,
+                                            :available_contexts,
                                             :set_context,
                                             :app_strings,
                                             :lock,

--- a/test/unit/ios/device_w3c_test.rb
+++ b/test/unit/ios/device_w3c_test.rb
@@ -16,7 +16,7 @@ class AppiumLibCoreTest
         array.each { |v| assert ::Appium::Core::Base::Bridge::W3C.method_defined?(v) }
       end
 
-      def test_no_arg_definitions
+      def test_with_arg_definitions
         parameterized_method_defined_check([:shake,
                                             :launch_app,
                                             :close_app,
@@ -24,11 +24,8 @@ class AppiumLibCoreTest
                                             :device_locked?,
                                             :unlock,
                                             :device_time,
-                                            :current_context])
-      end
-
-      def test_with_arg_definitions
-        parameterized_method_defined_check([:available_contexts,
+                                            :current_context,
+                                            :available_contexts,
                                             :set_context,
                                             :app_strings,
                                             :lock,


### PR DESCRIPTION
Getting rid of method generation for no argument commands to increase IDE support. (With RubyMine, we can't use code jump and assistants with before implementation, for example.)