### PR TITLE
Remove hotfix xcuitest pinch zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 ### Deprecations
+- Changed the name of arguments
+    - `swipe(start_x:, start_y:, end_x:, end_y:)` instead of `swipe(start_x:, start_y:, offset_x:, offset_y:)`
 
 ## [1.4.2] - 2018-04-22
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Enhancements
+- [internal] Remove hot fix for XCUITest action
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/device/touch_actions.rb
+++ b/lib/appium_lib_core/device/touch_actions.rb
@@ -143,11 +143,11 @@ module Appium
         end_y   = opts.fetch :end_y, 0
 
         if opts[:offset_x]
-          ::Appium::Logger.warn('[DEPRECATED] :offset_x will be :end_x to indicate as an absolute point.')
+          ::Appium::Logger.warn('[DEPRECATED] :offset_x was renamed to :end_x to indicate as an absolute point.')
           end_x = opts.fetch :offset_x, 0
         end
         if opts[:offset_y]
-          ::Appium::Logger.warn('[DEPRECATED] :offset_y will be :end_y to indicate as an absolute point.')
+          ::Appium::Logger.warn('[DEPRECATED] :offset_y was renamed to :end_y to indicate as an absolute point.')
           end_y = opts.fetch :offset_y, 0
         end
 

--- a/lib/appium_lib_core/device/touch_actions.rb
+++ b/lib/appium_lib_core/device/touch_actions.rb
@@ -136,21 +136,17 @@ module Appium
       # @option opts [int] :offset_x Move to the end, on the x axis.  Default 0.
       # @option opts [int] :offset_y Move to the end, on the y axis.  Default 0.
       # @option opts [int] :duration How long the actual swipe takes to complete in milliseconds. Default 200.
-      def swipe(opts, ele = nil)
+      def swipe(opts)
         start_x  = opts.fetch :start_x, 0
         start_y  = opts.fetch :start_y, 0
         offset_x = opts.fetch :offset_x, 0
         offset_y = opts.fetch :offset_y, 0
         duration = opts.fetch :duration, 200
 
-        if ele # pinch/zoom for XCUITest
-          press x: start_x, y: start_y, element: ele
-          move_to x: offset_x, y: offset_y, element: ele
-        else
-          press x: start_x, y: start_y
-          wait(duration) if duration
-          move_to x: offset_x, y: offset_y
-        end
+        press x: start_x, y: start_y
+        wait(duration) if duration
+        move_to x: offset_x, y: offset_y
+
         release
 
         self

--- a/lib/appium_lib_core/device/touch_actions.rb
+++ b/lib/appium_lib_core/device/touch_actions.rb
@@ -34,8 +34,8 @@ module Appium
       # `move_to`'s `x` and `y` have two case. One is working as coordinate, the other is working as offset.
       #
       # @param opts [Hash] Options
-      # @option opts [integer] :x x co-ordinate to move to if element isn't set. Works as an offset if x is set with Element.
-      # @option opts [integer] :y y co-ordinate to move to if element isn't set. Works as an offset if y is set with Element.
+      # @option opts [integer] :x x co-ordinate to move to if element isn't set. Works as an absolute if x is set with Element.
+      # @option opts [integer] :y y co-ordinate to move to if element isn't set. Works as an absolute if y is set with Element.
       # @option opts [WebDriver::Element] Element to scope this move within.
       def move_to(opts)
         opts = args_with_ele_ref(opts)
@@ -133,19 +133,29 @@ module Appium
       # @param opts [Hash] Options
       # @option opts [int] :start_x Where to start swiping, on the x axis.  Default 0.
       # @option opts [int] :start_y Where to start swiping, on the y axis.  Default 0.
-      # @option opts [int] :offset_x Move to the end, on the x axis.  Default 0.
-      # @option opts [int] :offset_y Move to the end, on the y axis.  Default 0.
+      # @option opts [int] :end_x Move to the end, on the x axis.  Default 0.
+      # @option opts [int] :end_y Move to the end, on the y axis.  Default 0.
       # @option opts [int] :duration How long the actual swipe takes to complete in milliseconds. Default 200.
       def swipe(opts)
-        start_x  = opts.fetch :start_x, 0
-        start_y  = opts.fetch :start_y, 0
-        offset_x = opts.fetch :offset_x, 0
-        offset_y = opts.fetch :offset_y, 0
+        start_x = opts.fetch :start_x, 0
+        start_y = opts.fetch :start_y, 0
+        end_x   = opts.fetch :end_x, 0
+        end_y   = opts.fetch :end_y, 0
+
+        if opts[:offset_x]
+          ::Appium::Logger.warn('[DEPRECATED] :offset_x will be :end_x to indicate as an absolute point.')
+          end_x = opts.fetch :offset_x, 0
+        end
+        if opts[:offset_y]
+          ::Appium::Logger.warn('[DEPRECATED] :offset_y will be :end_y to indicate as an absolute point.')
+          end_y = opts.fetch :offset_y, 0
+        end
+
         duration = opts.fetch :duration, 200
 
         press x: start_x, y: start_y
         wait(duration) if duration
-        move_to x: offset_x, y: offset_y
+        move_to x: end_x, y: end_y
 
         release
 

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -187,7 +187,7 @@ class AppiumLibCoreTest
         rect = el.rect
 
         Appium::Core::TouchAction.new(@@driver)
-                                 .swipe(start_x: 75, start_y: 500, offset_x: 75, offset_y: 500, duration: 500)
+                                 .swipe(start_x: 75, start_y: 500, end_x: 75, end_y: 500, duration: 500)
                                  .perform
         @@driver.back # The above command become "tap" action since it doesn't move.
         el = @@core.wait { @@driver.find_element :accessibility_id, 'Fragment' }
@@ -195,7 +195,7 @@ class AppiumLibCoreTest
         assert rect.y == el.rect.y
 
         touch_action = Appium::Core::TouchAction.new(@@driver)
-                                                .swipe(start_x: 75, start_y: 500, offset_x: 75, offset_y: 300, duration: 500)
+                                                .swipe(start_x: 75, start_y: 500, end_x: 75, end_y: 300, duration: 500)
 
         assert_equal :press, touch_action.actions[0][:action]
         assert_equal({ x: 75, y: 500 }, touch_action.actions[0][:options])

--- a/test/functional/ios/ios/device_test.rb
+++ b/test/functional/ios/ios/device_test.rb
@@ -165,13 +165,13 @@ class AppiumLibCoreTest
         rect = el.rect
 
         Appium::Core::TouchAction.new(@@driver)
-                                 .swipe(start_x: 75, start_y: 500, offset_x: 75, offset_y: 500, duration: 500)
+                                 .swipe(start_x: 75, start_y: 500, end_x: 75, end_y: 500, duration: 500)
                                  .perform
         assert rect.x == el.rect.x
         assert rect.y == el.rect.y
 
         touch_action = Appium::Core::TouchAction.new(@@driver)
-                                                .swipe(start_x: 75, start_y: 500, offset_x: 75, offset_y: 300, duration: 500)
+                                                .swipe(start_x: 75, start_y: 500, end_x: 75, end_y: 300, duration: 500)
 
         assert_equal :press, touch_action.actions[0][:action]
         assert_equal({ x: 75, y: 500 }, touch_action.actions[0][:options])


### PR DESCRIPTION
The hotfix was used by `ruby_lib` to keep compatibility.