### PR TITLE
set default content type

### DIFF
--- a/lib/appium_lib_core/common/base/http_default.rb
+++ b/lib/appium_lib_core/common/base/http_default.rb
@@ -5,7 +5,11 @@ module Appium
     class Base
       module Http
         class Default < Selenium::WebDriver::Remote::Http::Default
-          DEFAULT_HEADERS = { 'Accept' => CONTENT_TYPE, 'User-Agent' => "appium/ruby_lib_core/#{VERSION}" }.freeze
+          DEFAULT_HEADERS = {
+            'Accept' => CONTENT_TYPE,
+            'Content-Type' => "#{CONTENT_TYPE}; charset=UTF-8",
+            'User-Agent' => "appium/ruby_lib_core/#{VERSION}"
+          }.freeze
         end
       end
     end


### PR DESCRIPTION
Ruby core inherits selenium webdriver and define `DEFAULT_HEADERS` here.
I've added `Content-Type` as same as webdriver by default.
(I know it can case-insensitive, but it's because of following webdriver.)