### PR TITLE
use :app without modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Enhancements
+- Relax the logic of `:app` capability
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -394,11 +394,12 @@ module Appium
         return if @caps[:app] =~ URI::DEFAULT_PARSER.make_regexp
 
         app_path = File.expand_path(@caps[:app])
-        if File.exist? app_path
-          @caps[:app] = app_path
-        else
-          ::Appium::Logger.info("Use #{@caps[:app]} directly")
-        end
+        @caps[:app] = if File.exist? app_path
+                        app_path
+                      else
+                        ::Appium::Logger.info("Use #{@caps[:app]} directly")
+                        @caps[:app]
+                      end
       end
 
       # @private

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -387,12 +387,18 @@ module Appium
 
       # @private
       # Path to the .apk, .app or .app.zip.
-      # The path can be local or remote for Sauce.
+      # The path can be local, HTTP/S, Windows Share and other path like `sauce-storage:`.
+      # Use @caps[:app] without modifications if the path isn't HTTP/S or local path.
       def set_app_path
         return unless @caps && @caps[:app] && !@caps[:app].empty?
         return if @caps[:app] =~ URI::DEFAULT_PARSER.make_regexp
 
-        @caps[:app] = File.expand_path(@caps[:app])
+        app_path = File.expand_path(@caps[:app])
+        if File.exist? app_path
+          @caps[:app] = app_path
+        else
+          ::Appium::Logger.info("Use #{@caps[:app]} directly")
+        end
       end
 
       # @private

--- a/test/unit/common_test.rb
+++ b/test/unit/common_test.rb
@@ -81,7 +81,7 @@ class AppiumLibCoreTest
         driver
       end
 
-      def test_create_session_force_mjsonwp_with_http_package
+      def test_create_session_force_mjsonwp_with_source_package
         response = {
           status: 0, # To make bridge.dialect == :oss
           value: {
@@ -89,7 +89,7 @@ class AppiumLibCoreTest
             capabilities: {
               platformName: :android,
               automationName: 'uiautomator2',
-              app: 'test/functional/app/api.apk',
+              app: 'sauce-storage:test/functional/app/api.apk',
               platformVersion: '7.1.1',
               deviceName: 'Android Emulator',
               appPackage: 'io.appium.android.apis'
@@ -99,7 +99,7 @@ class AppiumLibCoreTest
         http_caps = {
           platformName: :android,
           automationName: 'uiautomator2',
-          app: 'http://example.com/test.apk.zip',
+          app: 'sauce-storage:test/functional/app/api.apk',
           platformVersion: '7.1.1',
           deviceName: 'Android Emulator',
           appPackage: 'io.appium.android.apis'
@@ -119,7 +119,7 @@ class AppiumLibCoreTest
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
         assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 20_000 }.to_json, times: 1)
 
-        assert_equal 'http://example.com/test.apk.zip', core.caps[:app]
+        assert_equal 'sauce-storage:test/functional/app/api.apk', core.caps[:app]
       end
 
       def test_create_session_w3c


### PR DESCRIPTION
When I checked ruby_lib code, i found below case.
https://wiki.saucelabs.com/display/DOCS/Uploading+Mobile+Applications+to+Sauce+Storage+for+Testing

Thus, I'd like to use `@caps[:app]` directly if it isn't http/s or local path with information log level.