### PR TITLE
use method missing for getting attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Enhancements
 - silence warning for pointeractions [#113](https://github.com/appium/ruby_lib_core/pull/113)
+- Use method missing to get attributes like `e.resource_id` instead of `e.attribute 'resource-id'` [#116](https://github.com/appium/ruby_lib_core/pull/116)
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/patch.rb
+++ b/lib/appium_lib_core/patch.rb
@@ -7,47 +7,33 @@ module Appium
       # To extend Appium related SearchContext into ::Selenium::WebDriver::Element
       include ::Appium::Core::Base::SearchContext
 
-      # Note: For testing .text should be used over value, and name.
-
-      # Returns the value attribute
+      # Returns the value of attributes
       #
-      # Fixes NoMethodError: undefined method `value' for Selenium::WebDriver::Element for iOS
+      # uiautomator2: https://github.com/appium/appium-uiautomator2-server/blob/203cc7e57ce477f3cff5d95b135d1b3450a6033a/app/src/main/java/io/appium/uiautomator2/utils/Attribute.java#L19
+      #     checkable, checked, class, clickable, content-desc, enabled, focusable, focused
+      #     long-clickable, package, password, resource-id, scrollable, selection-start, selection-end
+      #     selected, text, bounds, index
+      #
+      # XCUITest automation name support below attributes
+      #     UID, accessibilityContainer, accessible, enabled, frame,
+      #     label, name, rect, type, value, visible, wdAccessibilityContainer,
+      #     wdAccessible, wdEnabled, wdFrame, wdLabel, wdName, wdRect, wdType,
+      #     wdUID, wdValue, wdVisible
+      #
       # @return [String]
       #
       # @example
       #
       #   e = @driver.find_element :accessibility_id, 'something'
       #   e.value
+      #   e.resource_id # call `e.attribute "resource-id"`
       #
-      def value
-        attribute :value
+      def method_missing(method_name)
+        respond_to?(method_name) ? attribute(method_name.to_s.tr('_', '-')) : super
       end
 
-      # Returns the name attribute
-      #
-      # Fixes NoMethodError: undefined method `name' for Selenium::WebDriver::Element for iOS
-      # @return [String]
-      #
-      # @example
-      #
-      #   e = @driver.find_element :accessibility_id, 'something'
-      #   e.name
-      #
-      def name
-        attribute :name
-      end
-
-      # Enable access to iOS accessibility label
-      # accessibility identifier is supported as 'name'
-      # @return [String]
-      #
-      # @example
-      #
-      #   e = @driver.find_element :accessibility_id, 'something'
-      #   e.label
-      #
-      def label
-        attribute :label
+      def respond_to_missing?(*)
+        true
       end
 
       # Alias for type

--- a/lib/appium_lib_core/patch.rb
+++ b/lib/appium_lib_core/patch.rb
@@ -7,14 +7,14 @@ module Appium
       # To extend Appium related SearchContext into ::Selenium::WebDriver::Element
       include ::Appium::Core::Base::SearchContext
 
-      # Returns the value of attributes
+      # Returns the value of attributes like below. Read each platform to know more details.
       #
       # uiautomator2: https://github.com/appium/appium-uiautomator2-server/blob/203cc7e57ce477f3cff5d95b135d1b3450a6033a/app/src/main/java/io/appium/uiautomator2/utils/Attribute.java#L19
       #     checkable, checked, class, clickable, content-desc, enabled, focusable, focused
       #     long-clickable, package, password, resource-id, scrollable, selection-start, selection-end
       #     selected, text, bounds, index
       #
-      # XCUITest automation name support below attributes
+      # XCUITest automation name supports below attributes.
       #     UID, accessibilityContainer, accessible, enabled, frame,
       #     label, name, rect, type, value, visible, wdAccessibilityContainer,
       #     wdAccessible, wdEnabled, wdFrame, wdLabel, wdName, wdRect, wdType,

--- a/test/functional/android/patch_test.rb
+++ b/test/functional/android/patch_test.rb
@@ -16,25 +16,13 @@ class AppiumLibCoreTest
       save_reports(@@driver)
     end
 
-    def test_value
-      skip "Android doesn't support"
+    def test_method_missing_attributes
       e = @@core.wait { @@driver.find_element :accessibility_id, 'App' }
 
-      assert_equal 'App', e.value
-    end
-
-    def test_name
-      skip "Android doesn't support"
-      e = @@core.wait { @@driver.find_element :accessibility_id, 'App' }
-
-      assert_equal 'App', e.name
-    end
-
-    def test_label
-      skip "Android doesn't support"
-      e = @@core.wait { @@driver.find_element :accessibility_id, 'App' }
-
-      assert_equal 'App', e.label
+      assert_equal 'App', e.text
+      assert_equal 'App', e.enabled
+      assert_equal 'App', e.focused
+      assert_equal 'App', e.content_desc
     end
 
     def test_type

--- a/test/functional/ios/patch_test.rb
+++ b/test/functional/ios/patch_test.rb
@@ -13,21 +13,11 @@ class AppiumLibCoreTest
       save_reports(@@driver)
     end
 
-    def test_value
+    def test_method_missing_attributes
       e = @@core.wait { @@driver.find_element :accessibility_id, 'Buttons' }
 
       assert_equal 'Buttons', e.value
-    end
-
-    def test_name
-      e = @@core.wait { @@driver.find_element :accessibility_id, 'Buttons' }
-
       assert_equal 'Buttons', e.name
-    end
-
-    def test_label
-      e = @@core.wait { @@driver.find_element :accessibility_id, 'Buttons' }
-
       assert_equal 'Buttons', e.label
     end
 

--- a/test/unit/android/device/w3c/commands_test.rb
+++ b/test/unit/android/device/w3c/commands_test.rb
@@ -817,6 +817,16 @@ class AppiumLibCoreTest
             assert_requested(:post, "#{SESSION}/element", times: 1)
             assert_requested(:post, "#{SESSION}/element/element_id_parent/element", times: 1)
           end
+
+          def test_method_missing
+            stub_request(:get, "#{SESSION}/element/id/attribute/content-desc")
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+
+            e = ::Selenium::WebDriver::Element.new(@driver.send(:bridge), 'id')
+            e.content_desc
+
+            assert_requested(:get, "#{SESSION}/element/id/attribute/content-desc", times: 1)
+          end
         end # class CommandsTest
       end # module W3C
     end # module Device

--- a/test/unit/ios/device/w3c/commands_test.rb
+++ b/test/unit/ios/device/w3c/commands_test.rb
@@ -84,6 +84,16 @@ class AppiumLibCoreTest
             assert_equal :unplugged, info[:state]
             assert_equal 0.5, info[:level]
           end
+
+          def test_method_missing
+            stub_request(:get, "#{SESSION}/element/id/attribute/name")
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+
+            e = ::Selenium::WebDriver::Element.new(@driver.send(:bridge), 'id')
+            e.name
+
+            assert_requested(:get, "#{SESSION}/element/id/attribute/name", times: 1)
+          end
         end # class CommandsTest
       end # module W3C
     end # module Device


### PR DESCRIPTION
`attribites` we can get depends on platforms. Thus, it's easy to get me them based on method missing.