### PR TITLE
port send keys for an active element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Enhancements
 - Update documentation about `start_recording_screen`
+- Port `send_keys/type` for active element
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/common/base/bridge/w3c.rb
+++ b/lib/appium_lib_core/common/base/bridge/w3c.rb
@@ -67,7 +67,7 @@ module Appium
           # Port from MJSONWP
           def send_keys_to_active_element(key)
             text = ::Selenium::WebDriver::Keys.encode(key).join('')
-            execute :send_keys_to_active_element, {}, {value: text.split(//)}
+            execute :send_keys_to_active_element, {}, { value: text.split(//) }
           end
 
           # For Appium

--- a/lib/appium_lib_core/common/base/bridge/w3c.rb
+++ b/lib/appium_lib_core/common/base/bridge/w3c.rb
@@ -64,6 +64,12 @@ module Appium
             ::Selenium::WebDriver::Remote::W3C::Capabilities.json_create execute(:get_capabilities)
           end
 
+          # Port from MJSONWP
+          def send_keys_to_active_element(key)
+            text = ::Selenium::WebDriver::Keys.encode(key).join('')
+            execute :send_keys_to_active_element, {}, {value: text.split(//)}
+          end
+
           # For Appium
           # override
           def page_source

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -99,6 +99,18 @@ module Appium
           @bridge.is_keyboard_shown
         end
 
+        # Send keys for a current active element
+        # @param [String] key Input text
+        #
+        # @example
+        #
+        #   @driver.send_keys 'happy testing!'
+        #
+        def send_keys(*key)
+          @bridge.send_keys_to_active_element(key)
+        end
+        alias type send_keys
+
         # Get appium Settings for current test session
         #
         # @example

--- a/lib/appium_lib_core/common/command/w3c.rb
+++ b/lib/appium_lib_core/common/command/w3c.rb
@@ -33,6 +33,8 @@ module Appium
             ime_deactivate:            [:post, 'session/:session_id/ime/deactivate'.freeze],
             ime_activate_engine:       [:post, 'session/:session_id/ime/activate'.freeze],
 
+            send_keys_to_active_element: [:post, 'session/:session_id/keys'.freeze],
+
             ### Logs
             get_available_log_types:   [:get, 'session/:session_id/log/types'.freeze],
             get_log:                   [:post, 'session/:session_id/log'.freeze]

--- a/test/unit/android/device/mjsonwp/commands_test.rb
+++ b/test/unit/android/device/mjsonwp/commands_test.rb
@@ -161,7 +161,8 @@ class AppiumLibCoreTest
 
           def test_send_keys_for_active_elements
             stub_request(:post, "#{SESSION}/keys")
-              .to_return(headers: HEADER, status: 200, body: { value: ['h','a','p','p','y',' ','t','e','s','t','i','n','g'] }.to_json)
+              .to_return(headers: HEADER, status: 200, body:
+                { value: ['h', 'a', 'p', 'p', 'y', ' ', 't', 'e', 's', 't', 'i', 'n', 'g'] }.to_json)
 
             @driver.send_keys 'happy testing'
             @driver.type 'happy testing'

--- a/test/unit/android/device/mjsonwp/commands_test.rb
+++ b/test/unit/android/device/mjsonwp/commands_test.rb
@@ -159,6 +159,16 @@ class AppiumLibCoreTest
             assert_requested(:get, "#{SESSION}/appium/device/is_keyboard_shown", times: 1)
           end
 
+          def test_send_keys_for_active_elements
+            stub_request(:post, "#{SESSION}/keys")
+              .to_return(headers: HEADER, status: 200, body: { value: ['h','a','p','p','y',' ','t','e','s','t','i','n','g'] }.to_json)
+
+            @driver.send_keys 'happy testing'
+            @driver.type 'happy testing'
+
+            assert_requested(:post, "#{SESSION}/keys", times: 2)
+          end
+
           def test_get_network_connection
             stub_request(:get, "#{SESSION}/network_connection")
               .to_return(headers: HEADER, status: 200, body: { value: 'A' }.to_json)

--- a/test/unit/android/device/w3c/commands_test.rb
+++ b/test/unit/android/device/w3c/commands_test.rb
@@ -149,6 +149,16 @@ class AppiumLibCoreTest
             assert_requested(:get, "#{SESSION}/appium/device/display_density", times: 1)
           end
 
+          def test_send_keys_for_active_elements
+            stub_request(:post, "#{SESSION}/keys")
+              .to_return(headers: HEADER, status: 200, body: { value: ['h','a','p','p','y',' ','t','e','s','t','i','n','g'] }.to_json)
+
+            @driver.send_keys 'happy testing'
+            @driver.type 'happy testing'
+
+            assert_requested(:post, "#{SESSION}/keys", times: 2)
+          end
+
           def test_is_keyboard_shown
             stub_request(:get, "#{SESSION}/appium/device/is_keyboard_shown")
               .to_return(headers: HEADER, status: 200, body: { value: 'A' }.to_json)

--- a/test/unit/android/device/w3c/commands_test.rb
+++ b/test/unit/android/device/w3c/commands_test.rb
@@ -151,7 +151,8 @@ class AppiumLibCoreTest
 
           def test_send_keys_for_active_elements
             stub_request(:post, "#{SESSION}/keys")
-              .to_return(headers: HEADER, status: 200, body: { value: ['h','a','p','p','y',' ','t','e','s','t','i','n','g'] }.to_json)
+              .to_return(headers: HEADER, status: 200, body:
+                { value: ['h', 'a', 'p', 'p', 'y', ' ', 't', 'e', 's', 't', 'i', 'n', 'g'] }.to_json)
 
             @driver.send_keys 'happy testing'
             @driver.type 'happy testing'

--- a/test/unit/script/commands_test.rb
+++ b/test/unit/script/commands_test.rb
@@ -30,7 +30,7 @@ class ScriptTest
     end
 
     def test_implemented_w3c_commands
-      assert_equal 117, @c.implemented_w3c_commands.length
+      assert_equal 118, @c.implemented_w3c_commands.length
       assert_equal ['session/:session_id/contexts', [:get]], @c.implemented_w3c_commands.first
 
       # pick up an arbitrary command


### PR DESCRIPTION
With W3C, it will be
```
driver.action.send_keys('xxxx').perform
```

But we need to implement `type: key` in action in server side => example https://github.com/appium/appium-espresso-driver/pull/192/files