### PR TITLE
Fix raising error format and remove unnecessary fixme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Add missing `take_viewport_screenshot` for mjsonwp [#127](https://github.com/appium/ruby_lib_core/pull/127)
 
 ### Bug fixes
+- [internal] Fix raising error in `set_implicit_wait_by_default` [#130](https://github.com/appium/ruby_lib_core/issues/130)
 
 ### Deprecations
 

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -228,16 +228,7 @@ module Appium
         @driver.manage.timeouts.implicit_wait = wait
       rescue ::Selenium::WebDriver::Error::UnknownError => e
         unless e.message.include?('The operation requested is not yet implemented')
-          raise e.message, ::Appium::Core::Error::ServerError
-        end
-
-        Appium::Logger.debug(e.message)
-        {}
-      rescue ::Selenium::WebDriver::Error::WebDriverError => e
-        # FIXME: Temporary rescue until Appium support W3C's implicit wait
-        # https://github.com/jlipps/simple-wd-spec#set-timeouts
-        unless e.message.include?('Parameters were incorrect. We wanted {"required":["type","ms"]} and you sent ["implicit"]')
-          raise e.message, ::Appium::Core::Error::ServerError
+          raise ::Appium::Core::Error::ServerError, e.message
         end
 
         Appium::Logger.debug(e.message)


### PR DESCRIPTION
closes _Incorrect calls to `raise` in `set_implicit_wait_by_default` #130_