### PR TITLE
fix unexpected method missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 
 ### Bug fixes
+- fix unexpedted method missing against `:to_hash`
 
 ### Deprecations
 

--- a/lib/appium_lib_core/patch.rb
+++ b/lib/appium_lib_core/patch.rb
@@ -29,7 +29,14 @@ module Appium
       #   e.resource_id # call `e.attribute "resource-id"`
       #
       def method_missing(method_name)
-        respond_to?(method_name) ? attribute(method_name.to_s.tr('_', '-')) : super
+        white_list = [:content_desc, :long_clickable, :resource_id, :selection_start, :selection_end]
+        attribute_name = white_list.include?(method_name) ? method_name.to_s.tr('_', '-') : method_name
+
+        ignore_list = [:to_hash]
+
+        unless ignore_list.include? method_name
+          respond_to?(method_name) ? attribute(attribute_name) : super
+        end
       end
 
       def respond_to_missing?(*)

--- a/lib/appium_lib_core/patch.rb
+++ b/lib/appium_lib_core/patch.rb
@@ -34,9 +34,9 @@ module Appium
 
         ignore_list = [:to_hash]
 
-        unless ignore_list.include? method_name
-          respond_to?(method_name) ? attribute(attribute_name) : super
-        end
+        return if ignore_list.include? method_name
+
+        respond_to?(method_name) ? attribute(attribute_name) : super
       end
 
       def respond_to_missing?(*)


### PR DESCRIPTION
Raise an error unexpected method missing: method missing happened against `:to_hash`