### PR TITLE
get rid of self from Appium::Core.for(self, opts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 ### Deprecations
+- `@core = Appium::Core.for(self, opts)` is deprecated in favor of `@core = Appium::Core.for(opts)`
+    - Call `extend Appium::Core::Device` if you'd like to extend methods defined in `Appium::Core`
 
 ## [1.9.2] - 2018-08-23
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecations
 - `@core = Appium::Core.for(self, opts)` is deprecated in favor of `@core = Appium::Core.for(opts)`
     - Call `extend Appium::Core::Device` if you'd like to extend methods defined in `Appium::Core`
+        - Read [#816](https://github.com/appium/ruby_lib/pull/816) as an example
 
 ## [1.9.2] - 2018-08-23
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ opts = {
     wait: 30
   }
 }
-@core = Appium::Core.for(self, opts) # create a core driver with `opts` and extend methods into `self`
+@core = Appium::Core.for(opts) # create a core driver with `opts`
 @driver = @core.start_driver
 
 # Launch iPhone Simulator and `MyiOS.app`

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Run functional tests which require the Appium server and real device, Simulator/
 
 - Start Appium server
  ```bash
-$ npm install -g appium
-$ appium
+$ npm install -g appium opencv4nodejs
+$ appium --relaxed-security # To run all tests in rocal
 ```
 
 - Conduct tests

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -67,7 +67,7 @@ module Appium
         #       wait: 30
         #     }
         #   }
-        #   core = ::Appium::Core.for(self, caps)
+        #   core = ::Appium::Core.for(caps)
         #   driver = core.start_driver #=> driver.dialect == :oss
         #
         # @example
@@ -85,7 +85,7 @@ module Appium
         #       wait: 30
         #     }
         #   }
-        #   core = ::Appium::Core.for(self, caps)
+        #   core = ::Appium::Core.for(caps)
         #   driver = core.start_driver #=> driver.dialect == :w3c if the Appium server support W3C.
         #
         def create_session(desired_capabilities)

--- a/lib/appium_lib_core/common/touch_action/multi_touch.rb
+++ b/lib/appium_lib_core/common/touch_action/multi_touch.rb
@@ -9,7 +9,7 @@ module Appium
     #
     # @example
     #
-    #   @driver = Appium::Core.for(self, opts).start_driver
+    #   @driver = Appium::Core.for(opts).start_driver
     #   action_1 = TouchAction.new(@driver).press(x: 45, y: 100).wait(5).release
     #   action_2 = TouchAction.new(@driver).tap(element: el, x: 50, y:5, count: 3)
     #

--- a/lib/appium_lib_core/common/touch_action/touch_actions.rb
+++ b/lib/appium_lib_core/common/touch_action/touch_actions.rb
@@ -12,7 +12,7 @@ module Appium
     #
     # @example
     #
-    #   @driver = Appium::Core.for(self, opts).start_driver
+    #   @driver = Appium::Core.for(opts).start_driver
     #   action = TouchAction.new(@driver).press(x: 45, y: 100).wait(5).release
     #   action.perform
     #   action = TouchAction.new(@driver).swipe(....)

--- a/lib/appium_lib_core/device.rb
+++ b/lib/appium_lib_core/device.rb
@@ -7,7 +7,7 @@ module Appium
         def extended(_mod)
           extend_webdriver_with_forwardable
 
-          # Compatibility for appium_lib
+          # Compatibility for appium_lib. Below command are extended by `extend Appium::Core::Deivce`in appium_lib.
           # TODO: Will remove
           [
             :take_element_screenshot, :save_viewport_screenshot,

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -319,8 +319,8 @@ module Appium
 
       # @private
       def extend_for(device:, automation_name:)
-        self.extend Appium::Core
-        self.extend Appium::Core::Device
+        extend Appium::Core
+        extend Appium::Core::Device
 
         case device
         when :android

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -103,7 +103,7 @@ module Appium
       #                listener: nil,
       #              }
       #            }
-      #     @core = Appium::Core.for(self, opts) # create a core driver with `opts` and extend methods into `self`
+      #     @core = Appium::Core.for(opts) # create a core driver with `opts` and extend methods into `self`
       #     @core.start_driver(server_url: server_url) # start driver
       #
       #     # Start iOS driver with .zip file over HTTP
@@ -125,11 +125,11 @@ module Appium
       #                listener: nil,
       #              }
       #            }
-      #     @core = Appium::Core.for(self, opts)
+      #     @core = Appium::Core.for(opts)
       #     @core.start_driver(server_url: server_url)
       #
-      def self.for(target, opts = {})
-        new(target, opts)
+      def self.for(opts = {})
+        new(opts)
       end
 
       # @private
@@ -139,8 +139,8 @@ module Appium
       end
 
       # @private
-      def initialize(target, opts = {})
-        @delegate_target = target # for testing purpose
+      def initialize(opts = {})
+        @delegate_target = self # for testing purpose
 
         opts = Appium.symbolize_keys opts
         validate_keys(opts)
@@ -152,7 +152,7 @@ module Appium
         set_appium_device
         set_automation_name
 
-        extend_for(device: @device, automation_name: @automation_name, target: target)
+        extend_for(device: @device, automation_name: @automation_name)
 
         self # rubocop:disable Lint/Void
       end
@@ -190,8 +190,8 @@ module Appium
       #              }
       #            }
       #
-      #     @core = Appium::Core.for(self, opts) # create a core driver with `opts` and extend methods into `self`
-      #     @driver = @core.start_driver
+      #     @core = Appium::Core.for(opts) # create a core driver with `opts` and extend methods into `self`
+      #     @driver = @core.start_driver server_url: "http://127.0.0.1:8000/wd/hub"
       #
 
       def start_driver(server_url: nil,
@@ -318,9 +318,9 @@ module Appium
       private
 
       # @private
-      def extend_for(device:, automation_name:, target:)
-        target.extend Appium::Core
-        target.extend Appium::Core::Device
+      def extend_for(device:, automation_name:)
+        self.extend Appium::Core
+        self.extend Appium::Core::Device
 
         case device
         when :android
@@ -352,7 +352,7 @@ module Appium
           Appium::Logger.warn('no device matched')
         end
 
-        target
+        self
       end
 
       # @private

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
   module Android
     class DeviceTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.android)
+        @@core ||= ::Appium::Core.for(Caps.android)
         @driver = @@core.start_driver
       end
 

--- a/test/functional/android/android/search_context_test.rb
+++ b/test/functional/android/android/search_context_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
   module Android
     class SearchContextTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.android)
+        @@core ||= ::Appium::Core.for(Caps.android)
         @driver = @@core.start_driver
       end
 

--- a/test/functional/android/driver_test.rb
+++ b/test/functional/android/driver_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class AppiumLibCoreTest
   class DriverTest < AppiumLibCoreTest::Function::TestCase
     def setup
-      @@core ||= ::Appium::Core.for(self, Caps.android)
+      @@core ||= ::Appium::Core.for(Caps.android)
       @driver = @@core.start_driver
     end
 

--- a/test/functional/android/patch_test.rb
+++ b/test/functional/android/patch_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class AppiumLibCoreTest
   class PathTest < AppiumLibCoreTest::Function::TestCase
     def setup
-      @@core ||= ::Appium::Core.for(self, Caps.android)
+      @@core ||= ::Appium::Core.for(Caps.android)
       @driver = @@core.start_driver
     end
 

--- a/test/functional/android/webdriver/create_session_test.rb
+++ b/test/functional/android/webdriver/create_session_test.rb
@@ -7,7 +7,7 @@ class AppiumLibCoreTest
       def test_mjsonwp
         caps = Caps.android[:caps].merge({ forceMjsonwp: true })
         new_caps = Caps.android.merge({ caps: caps })
-        core = ::Appium::Core.for(self, new_caps)
+        core = ::Appium::Core.for(new_caps)
 
         driver = core.start_driver
 
@@ -20,7 +20,7 @@ class AppiumLibCoreTest
       def test_w3c
         caps = Caps.android[:caps].merge({ forceMjsonwp: false })
         new_caps = Caps.android.merge({ caps: caps })
-        core = ::Appium::Core.for(self, new_caps)
+        core = ::Appium::Core.for(new_caps)
 
         driver = core.start_driver
 
@@ -32,7 +32,7 @@ class AppiumLibCoreTest
       # Require Appium 1.7.2+
       def test_w3c_default
         caps = Caps.android
-        core = ::Appium::Core.for(self, caps)
+        core = ::Appium::Core.for(caps)
 
         driver = core.start_driver
 

--- a/test/functional/android/webdriver/device_test.rb
+++ b/test/functional/android/webdriver/device_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
   module WebDriver
     class DeviceTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.android)
+        @@core ||= ::Appium::Core.for(Caps.android)
         @driver = @@core.start_driver
       end
 

--- a/test/functional/android/webdriver/w3c_actions_test.rb
+++ b/test/functional/android/webdriver/w3c_actions_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
   module WebDriver
     class W3CActionsTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.android)
+        @@core ||= ::Appium::Core.for(Caps.android)
         @driver = @@core.start_driver
       end
 

--- a/test/functional/ios/driver_test.rb
+++ b/test/functional/ios/driver_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class AppiumLibCoreTest
   class DriverTest < AppiumLibCoreTest::Function::TestCase
     def setup
-      @@core ||= ::Appium::Core.for(self, Caps.ios)
+      @@core ||= ::Appium::Core.for(Caps.ios)
       @@driver ||= @@core.start_driver
     end
 

--- a/test/functional/ios/ios/device_test.rb
+++ b/test/functional/ios/ios/device_test.rb
@@ -7,7 +7,7 @@ class AppiumLibCoreTest
   module Ios
     class DeviceTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.ios)
+        @@core ||= ::Appium::Core.for(Caps.ios)
         @@driver ||= @@core.start_driver
       end
 

--- a/test/functional/ios/ios/search_context_test.rb
+++ b/test/functional/ios/ios/search_context_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
   module Ios
     class SearchContextTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.ios)
+        @@core ||= ::Appium::Core.for(Caps.ios)
         @@driver ||= @@core.start_driver
       end
 

--- a/test/functional/ios/patch_test.rb
+++ b/test/functional/ios/patch_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class AppiumLibCoreTest
   class PathTest < AppiumLibCoreTest::Function::TestCase
     def setup
-      @@core ||= ::Appium::Core.for(self, Caps.ios)
+      @@core ||= ::Appium::Core.for(Caps.ios)
       @@driver ||= @@core.start_driver
     end
 

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -7,7 +7,7 @@ class AppiumLibCoreTest
       def test_mjsonwp
         caps = Caps.ios[:caps].merge({ forceMjsonwp: true })
         new_caps = Caps.ios.merge({ caps: caps })
-        core = ::Appium::Core.for(self, new_caps)
+        core = ::Appium::Core.for(new_caps)
 
         driver = core.start_driver
 
@@ -20,7 +20,7 @@ class AppiumLibCoreTest
       def test_w3c
         caps = Caps.ios[:caps].merge({ forceMjsonwp: false })
         new_caps = Caps.ios.merge({ caps: caps })
-        core = ::Appium::Core.for(self, new_caps)
+        core = ::Appium::Core.for(new_caps)
 
         driver = core.start_driver
 
@@ -32,7 +32,7 @@ class AppiumLibCoreTest
       # Require Appium 1.7.2+
       def test_w3c_default
         caps = Caps.ios
-        core = ::Appium::Core.for(self, caps)
+        core = ::Appium::Core.for(caps)
 
         driver = core.start_driver
 

--- a/test/functional/ios/webdriver/device_test.rb
+++ b/test/functional/ios/webdriver/device_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
   module WebDriver
     class DeviceTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.ios)
+        @@core ||= ::Appium::Core.for(Caps.ios)
         @@driver ||= @@core.start_driver
       end
 

--- a/test/functional/ios/webdriver/w3c_actions_test.rb
+++ b/test/functional/ios/webdriver/w3c_actions_test.rb
@@ -6,7 +6,7 @@ class AppiumLibCoreTest
   module WebDriver
     class W3CActionsTest < AppiumLibCoreTest::Function::TestCase
       def setup
-        @@core ||= ::Appium::Core.for(self, Caps.ios)
+        @@core ||= ::Appium::Core.for(Caps.ios)
         @@driver ||= @@core.start_driver
       end
 

--- a/test/unit/android/device/mjsonwp/app_management_test.rb
+++ b/test/unit/android/device/mjsonwp/app_management_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/commands_test.rb
+++ b/test/unit/android/device/mjsonwp/commands_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/contexts_test.rb
+++ b/test/unit/android/device/mjsonwp/contexts_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/definition_test.rb
+++ b/test/unit/android/device/mjsonwp/definition_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/device_lock_test.rb
+++ b/test/unit/android/device/mjsonwp/device_lock_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/image_comparison_test.rb
+++ b/test/unit/android/device/mjsonwp/image_comparison_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/ime_actions_test.rb
+++ b/test/unit/android/device/mjsonwp/ime_actions_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/keyboard_test.rb
+++ b/test/unit/android/device/mjsonwp/keyboard_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/mjsonwp/screenshot_test.rb
+++ b/test/unit/android/device/mjsonwp/screenshot_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/device/w3c/app_management_test.rb
+++ b/test/unit/android/device/w3c/app_management_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/commands_test.rb
+++ b/test/unit/android/device/w3c/commands_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/contexts_test.rb
+++ b/test/unit/android/device/w3c/contexts_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/definition_test.rb
+++ b/test/unit/android/device/w3c/definition_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/device_lock_test.rb
+++ b/test/unit/android/device/w3c/device_lock_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/image_comparison_test.rb
+++ b/test/unit/android/device/w3c/image_comparison_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/ime_actions_test.rb
+++ b/test/unit/android/device/w3c/ime_actions_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/keyboard_test.rb
+++ b/test/unit/android/device/w3c/keyboard_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/device/w3c/screenshot_test.rb
+++ b/test/unit/android/device/w3c/screenshot_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/webdriver/mjsonwp/alerts_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/alerts_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/webdriver/mjsonwp/commands_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/commands_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/webdriver/mjsonwp/timeouts_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/timeouts_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session
           end
 

--- a/test/unit/android/webdriver/w3c/actions_test.rb
+++ b/test/unit/android/webdriver/w3c/actions_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/webdriver/w3c/alerts_test.rb
+++ b/test/unit/android/webdriver/w3c/alerts_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/webdriver/w3c/commands_test.rb
+++ b/test/unit/android/webdriver/w3c/commands_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/android/webdriver/w3c/timeouts_test.rb
+++ b/test/unit/android/webdriver/w3c/timeouts_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.android)
+            @core ||= ::Appium::Core.for(Caps.android)
             @driver ||= android_mock_create_session_w3c
           end
 

--- a/test/unit/common/element_test.rb
+++ b/test/unit/common/element_test.rb
@@ -7,7 +7,7 @@ class AppiumLibCoreTest
     include AppiumLibCoreTest::Mock
 
     def setup
-      @core ||= ::Appium::Core.for(self, Caps.android)
+      @core ||= ::Appium::Core.for(Caps.android)
       @driver ||= android_mock_create_session_w3c
     end
 

--- a/test/unit/common_test.rb
+++ b/test/unit/common_test.rb
@@ -55,7 +55,7 @@ class AppiumLibCoreTest
           .with(body: { ms: 20_000 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
-        driver = ::Appium::Core.for(self, { caps: CAPS.merge({ forceMjsonwp: true }), appium_lib: {} }).start_driver
+        driver = ::Appium::Core.for({ caps: CAPS.merge({ forceMjsonwp: true }), appium_lib: {} }).start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
         assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 20_000 }.to_json, times: 1)
@@ -74,7 +74,7 @@ class AppiumLibCoreTest
           .with(body: { implicit: 20_000 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
-        driver = ::Appium::Core.for(self, { caps: CAPS.merge({ forceMjsonwp: false }), appium_lib: {} }).start_driver
+        driver = ::Appium::Core.for({ caps: CAPS.merge({ forceMjsonwp: false }), appium_lib: {} }).start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
         assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 20_000 }.to_json, times: 1)
@@ -113,7 +113,7 @@ class AppiumLibCoreTest
           .with(body: { ms: 20_000 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
-        core = ::Appium::Core.for(self, { caps: http_caps.merge({ forceMjsonwp: true }), appium_lib: {} })
+        core = ::Appium::Core.for({ caps: http_caps.merge({ forceMjsonwp: true }), appium_lib: {} })
         core.start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
@@ -134,7 +134,7 @@ class AppiumLibCoreTest
           .with(body: { implicit: 20_000 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
-        driver = ::Appium::Core.for(self, { caps: CAPS, appium_lib: {} }).start_driver
+        driver = ::Appium::Core.for({ caps: CAPS, appium_lib: {} }).start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
         assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 20_000 }.to_json, times: 1)
@@ -182,7 +182,7 @@ class AppiumLibCoreTest
           .with(body: { implicit: 20_000 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
-        core = ::Appium::Core.for(self, { caps: http_caps, appium_lib: {} })
+        core = ::Appium::Core.for({ caps: http_caps, appium_lib: {} })
         core.start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -5,12 +5,12 @@ class AppiumLibCoreTest
     include AppiumLibCoreTest::Mock
 
     def setup
-      @core ||= ::Appium::Core.for(self, Caps.android)
+      @core ||= ::Appium::Core.for(Caps.android)
     end
 
     class ExampleDriver
       def initialize(opts)
-        ::Appium::Core.for(self, opts)
+        ::Appium::Core.for(opts)
       end
     end
 

--- a/test/unit/image_element_test.rb
+++ b/test/unit/image_element_test.rb
@@ -5,7 +5,7 @@ class AppiumLibCoreTest
     include AppiumLibCoreTest::Mock
 
     def setup
-      @core ||= ::Appium::Core.for(self, Caps.ios)
+      @core ||= ::Appium::Core.for(Caps.ios)
     end
 
     def test_mjsonwp

--- a/test/unit/ios/device/mjsonwp/commands_test.rb
+++ b/test/unit/ios/device/mjsonwp/commands_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.ios)
+            @core ||= ::Appium::Core.for(Caps.ios)
             @driver ||= ios_mock_create_session
           end
 

--- a/test/unit/ios/device/mjsonwp/definition_test.rb
+++ b/test/unit/ios/device/mjsonwp/definition_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.ios)
+            @core ||= ::Appium::Core.for(Caps.ios)
             @driver ||= ios_mock_create_session
           end
 

--- a/test/unit/ios/device/w3c/commands_test.rb
+++ b/test/unit/ios/device/w3c/commands_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.ios)
+            @core ||= ::Appium::Core.for(Caps.ios)
             @driver ||= ios_mock_create_session_w3c
           end
 

--- a/test/unit/ios/device/w3c/definition_test.rb
+++ b/test/unit/ios/device/w3c/definition_test.rb
@@ -10,7 +10,7 @@ class AppiumLibCoreTest
           include AppiumLibCoreTest::Mock
 
           def setup
-            @core ||= ::Appium::Core.for(self, Caps.ios)
+            @core ||= ::Appium::Core.for(Caps.ios)
             @driver ||= ios_mock_create_session_w3c
           end
 


### PR DESCRIPTION
📝 
We must `extend` in appium_lib layer.

--

- [x] test:func:android
- [x] test:func:ios