### PR TITLE
fix capabilities for selenium grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 
 ### Bug fixes
+- Fix desired capability for W3C protocol under selenium grid environment [#137](https://github.com/appium/ruby_lib_core/issues/137)
 
 ### Deprecations
 

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -19,13 +19,13 @@ module Appium
         # @return [Bridge::MJSONWP, Bridge::W3C]
         #
         def self.handshake(**opts)
-          desired_capabilities = opts.delete(:desired_capabilities)
+          desired_capabilities = opts.delete(:desired_capabilities) { ::Selenium::WebDriver::Remote::Capabilities.new }
 
           if desired_capabilities.is_a?(Symbol)
             unless ::Selenium::WebDriver::Remote::Capabilities.respond_to?(desired_capabilities)
               raise ::Selenium::WebDriver::Error::WebDriverError, "invalid desired capability: #{desired_capabilities.inspect}"
             end
-            desired_capabilities = Remote::Capabilities.__send__(desired_capabilities)
+            desired_capabilities = ::Selenium::WebDriver::Remote::Capabilities.__send__(desired_capabilities)
           end
 
           bridge = new(opts)
@@ -192,8 +192,7 @@ module Appium
             {
               desiredCapabilities: desired_capabilities,
               capabilities: {
-                alwaysMatch: w3c_capabilities,
-                firstMatch: [{}]
+                firstMatch: [w3c_capabilities]
               }
             }
           end

--- a/test/unit/common_test.rb
+++ b/test/unit/common_test.rb
@@ -67,7 +67,7 @@ class AppiumLibCoreTest
 
         stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
           .with(body: { desiredCapabilities: CAPS,
-                        capabilities: { alwaysMatch: APPIUM_PREFIX_CAPS, firstMatch: [{}] } }.to_json)
+                        capabilities: { firstMatch: [APPIUM_PREFIX_CAPS] } }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts")
@@ -127,7 +127,7 @@ class AppiumLibCoreTest
 
         stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
           .with(body: { desiredCapabilities: CAPS,
-                        capabilities: { alwaysMatch: APPIUM_PREFIX_CAPS, firstMatch: [{}] } }.to_json)
+                        capabilities: { firstMatch: [APPIUM_PREFIX_CAPS] } }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts")
@@ -175,7 +175,7 @@ class AppiumLibCoreTest
 
         stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
           .with(body: { desiredCapabilities: http_caps,
-                        capabilities: { alwaysMatch: appium_prefix_http_caps, firstMatch: [{}] } }.to_json)
+                        capabilities: { firstMatch: [appium_prefix_http_caps] } }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts")


### PR DESCRIPTION
Fix w3c capabilities in handshake #137 

The capability is following selenium-webdriver.

https://github.com/SeleniumHQ/selenium/blame/07a18746ff756e90fd79ef253a328bd7dfa9e6dc/rb/lib/selenium/webdriver/remote/bridge.rb