### PR TITLE
Sends strict base64 format to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Read `release_notes.md` for commit level details.
 
 ## [Unreleased]
 ### Enhancements
-
+- Use `Base64.strict_encode64` when this client sends `Base64` encoded data to server
+    - Follows RFC 4648 format. It should not affect server side which is front Appium node server
+    - Continues to decode base 64 data following `decode64` to accept RFC 2045 format
+    
 ### Bug fixes
 
 ### Deprecations

--- a/lib/appium_lib_core/android/device/clipboard.rb
+++ b/lib/appium_lib_core/android/device/clipboard.rb
@@ -27,7 +27,7 @@ module Appium
 
                 params = {
                   contentType: content_type,
-                  content: Base64.encode64(content)
+                  content: Base64.strict_encode64(content)
                 }
                 params[:label] = label unless label.nil?
 

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -862,7 +862,7 @@ module Appium
         #     e = @@driver.find_element_by_image './test/functional/data/test_element_image.png'
         #
         def find_element_by_image(img_path)
-          template = Base64.encode64 File.read img_path
+          template = Base64.strict_encode64 File.read img_path
           find_element :image, template
         end
 
@@ -884,7 +884,7 @@ module Appium
         #     e == [] # if the `e` is empty
         #
         def find_elements_by_image(img_path)
-          template = Base64.encode64 File.read img_path
+          template = Base64.strict_encode64 File.read img_path
           find_elements :image, template
         end
       end # class Driver

--- a/lib/appium_lib_core/common/base/search_context.rb
+++ b/lib/appium_lib_core/common/base/search_context.rb
@@ -53,7 +53,7 @@ module Appium
         #     find_elements :accessibility_id, 'Animation'
         #
         #     # with base64 encoded template image. All platforms.
-        #     find_elements :image, Base64.encode64(File.read(file_path))
+        #     find_elements :image, Base64.strict_encode64(File.read(file_path))
         #
         #     # For Android
         #     ## With uiautomator

--- a/lib/appium_lib_core/common/device/file_management.rb
+++ b/lib/appium_lib_core/common/device/file_management.rb
@@ -6,7 +6,7 @@ module Appium
       module Device
         module FileManagement
           def push_file(path, filedata)
-            encoded_data = Base64.encode64 filedata
+            encoded_data = Base64.strict_encode64 filedata
             execute :push_file, {}, path: path, data: encoded_data
           end
 

--- a/lib/appium_lib_core/common/device/image_comparison.rb
+++ b/lib/appium_lib_core/common/device/image_comparison.rb
@@ -151,8 +151,8 @@ module Appium
 
             params = {}
             params[:mode] = mode
-            params[:firstImage] = Base64.encode64 first_image
-            params[:secondImage] = Base64.encode64 second_image
+            params[:firstImage] = Base64.strict_encode64 first_image
+            params[:secondImage] = Base64.strict_encode64 second_image
             params[:options] = options if options
 
             execute(:compare_images, {}, params)

--- a/lib/appium_lib_core/ios/device/clipboard.rb
+++ b/lib/appium_lib_core/ios/device/clipboard.rb
@@ -27,7 +27,7 @@ module Appium
 
                 params = {
                   contentType: content_type,
-                  content: Base64.encode64(content)
+                  content: Base64.strict_encode64(content)
                 }
 
                 execute(:set_clipboard, {}, params)

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -150,7 +150,8 @@ class AppiumLibCoreTest
       end
 
       def test_push_and_pull_file
-        file = 'A Fine Day'
+        file = 'aVZCT1J3MEtHZ29BQUF BTlNVaEVVZ0FBQXU0QUFB VTJDQUlBQUFCRnRhUl' \
+          'JBQUFBQVhOU1IwSUFyczRjNlFBQQ0KQUJ4cFJFOVVBQUFBQWdBQUFBQUFBQUti'
         path = '/data/local/tmp/remote.txt'
         @@core.wait do
           @driver.push_file path, file

--- a/test/functional/android/android/mobile_commands_test.rb
+++ b/test/functional/android/android/mobile_commands_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-# $ rake test:func:ios TEST=test/functional/android/android/mobile_commands_test.rb
+# $ rake test:func:android TEST=test/functional/android/android/mobile_commands_test.rb
 class AppiumLibCoreTest
   module Android
     class MobileCommandsTest < AppiumLibCoreTest::Function::TestCase

--- a/test/functional/ios/ios/mobile_commands_test.rb
+++ b/test/functional/ios/ios/mobile_commands_test.rb
@@ -28,6 +28,25 @@ class AppiumLibCoreTest
         assert_equal 'John Appleseed', elements[0].value
       end
 
+      def test_pasteboard
+        @driver ||= @core.start_driver
+
+        message = 'happy appium'
+
+        args = { content: message }
+        @driver.execute_script 'mobile: setPasteboard', args
+        assert_equal message, @driver.get_clipboard
+
+        # Base64 which follows RFC 2045 inserts new line every 60 chars
+        # Ruby client sends it as RFC 4648 (Base64.strict_encode64)
+        message = 'ハッピー testing GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+        args = { content: message, encoding: 'utf-8' }
+        @driver.execute_script 'mobile: setPasteboard', args
+
+        # Ruby decode the string as ASCII-8BIT in Base64.encode64
+        assert_equal message, @driver.get_clipboard.force_encoding('utf-8')
+      end
+
       # @since Appium 1.10.0
       # Requires simulator
       def test_permission

--- a/test/functional/ios/webdriver/device_test.rb
+++ b/test/functional/ios/webdriver/device_test.rb
@@ -151,8 +151,8 @@ class AppiumLibCoreTest
         assert_equal File.size(lower_again_image_path), File.size(lower_image_path)
 
         # make sure the screenshot is png
-        assert Base64.encode64(File.read(lower_image_path)).start_with?('iVBOR')
-        assert Base64.encode64(File.read(higher_image_path)).start_with?('iVBOR')
+        assert Base64.strict_encode64(File.read(lower_image_path)).start_with?('iVBOR')
+        assert Base64.strict_encode64(File.read(higher_image_path)).start_with?('iVBOR')
       end
     end
   end

--- a/test/unit/android/device/mjsonwp/image_comparison_test.rb
+++ b/test/unit/android/device/mjsonwp/image_comparison_test.rb
@@ -18,8 +18,8 @@ class AppiumLibCoreTest
           def test_image_comparison
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :matchFeatures,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2') }.to_json)
+                            firstImage: Base64.strict_encode64('image1'),
+                            secondImage: Base64.strict_encode64('image2') }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
             @driver.compare_images first_image: 'image1', second_image: 'image2'
@@ -28,43 +28,52 @@ class AppiumLibCoreTest
           end
 
           def test_image_comparison_match_images_features
+            img1 = 'img1GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+            img2 = 'img2GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :matchFeatures,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2'),
+                            firstImage: Base64.strict_encode64(img1),
+                            secondImage: Base64.strict_encode64(img2),
                             options: { detectorName: 'ORB',
                                        matchFunc: 'BruteForce',
                                        goodMatchesFactor: 100,
                                        visualize: false } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.match_images_features first_image: 'image1', second_image: 'image2', good_matches_factor: 100
+            @driver.match_images_features first_image: img1, second_image: img2, good_matches_factor: 100
 
             assert_requested(:post, "#{SESSION}/appium/compare_images", times: 1)
           end
 
           def test_image_comparison_find_image_occurrence
+            img1 = 'img1GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+            img2 = 'img2GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :matchTemplate,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2'),
+                            firstImage: Base64.strict_encode64(img1),
+                            secondImage: Base64.strict_encode64(img2),
                             options: { visualize: false } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.find_image_occurrence full_image: 'image1', partial_image: 'image2'
+            @driver.find_image_occurrence full_image: img1, partial_image: img2
 
             assert_requested(:post, "#{SESSION}/appium/compare_images", times: 1)
           end
 
           def test_image_comparison_get_images_similarity
+            img1 = 'img1GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+            img2 = 'img2GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :getSimilarity,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2'),
+                            firstImage: Base64.strict_encode64(img1),
+                            secondImage: Base64.strict_encode64(img2),
                             options: { visualize: false } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.get_images_similarity first_image: 'image1', second_image: 'image2'
+            @driver.get_images_similarity first_image: img1, second_image: img2
 
             assert_requested(:post, "#{SESSION}/appium/compare_images", times: 1)
           end

--- a/test/unit/android/device/w3c/image_comparison_test.rb
+++ b/test/unit/android/device/w3c/image_comparison_test.rb
@@ -15,55 +15,67 @@ class AppiumLibCoreTest
           end
 
           def test_image_comparison
+            img1 = 'img1GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+            img2 = 'img2GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :matchFeatures,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2') }.to_json)
+                            firstImage: Base64.strict_encode64(img1),
+                            secondImage: Base64.strict_encode64(img2) }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.compare_images first_image: 'image1', second_image: 'image2'
+            @driver.compare_images first_image: img1, second_image: img2
 
             assert_requested(:post, "#{SESSION}/appium/compare_images", times: 1)
           end
 
           def test_image_comparison_match_images_features
+            img1 = 'img1GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+            img2 = 'img2GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :matchFeatures,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2'),
+                            firstImage: Base64.strict_encode64(img1),
+                            secondImage: Base64.strict_encode64(img2),
                             options: { detectorName: 'ORB',
                                        matchFunc: 'BruteForce',
                                        goodMatchesFactor: 100,
                                        visualize: false } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.match_images_features first_image: 'image1', second_image: 'image2', good_matches_factor: 100
+            @driver.match_images_features first_image: img1, second_image: img2, good_matches_factor: 100
 
             assert_requested(:post, "#{SESSION}/appium/compare_images", times: 1)
           end
 
           def test_image_comparison_find_image_occurrence
+            img1 = 'img1GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+            img2 = 'img2GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :matchTemplate,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2'),
+                            firstImage: Base64.strict_encode64(img1),
+                            secondImage: Base64.strict_encode64(img2),
                             options: { visualize: false } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.find_image_occurrence full_image: 'image1', partial_image: 'image2'
+            @driver.find_image_occurrence full_image: img1, partial_image: img2
 
             assert_requested(:post, "#{SESSION}/appium/compare_images", times: 1)
           end
 
           def test_image_comparison_get_images_similarity
+            img1 = 'img1GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+            img2 = 'img2GgoAAAANSUhEUgAAAu4AAAU2CAIAAABFtaRRAAAAAXNSR0IArs4c6QAAABxpRE9UAAAAAgAAAAAAAA'
+
             stub_request(:post, "#{SESSION}/appium/compare_images")
               .with(body: { mode: :getSimilarity,
-                            firstImage: Base64.encode64('image1'),
-                            secondImage: Base64.encode64('image2'),
+                            firstImage: Base64.strict_encode64(img1),
+                            secondImage: Base64.strict_encode64(img2),
                             options: { visualize: false } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.get_images_similarity first_image: 'image1', second_image: 'image2'
+            @driver.get_images_similarity first_image: img1, second_image: img2
 
             assert_requested(:post, "#{SESSION}/appium/compare_images", times: 1)
           end


### PR DESCRIPTION
- Send base64 format following RFC 4648
    - Just make format strict. I tested this does not affect node front Appium server with some image/content scenarios

---

note:
WDA => Appium was probably following RFC 2045 since the data had `\n`.
Appium returns RFC 4648, basically. (nodejs's base64)

Ruby can decode both of them with `Base64.decode64` (I have not changed decode related code)

https://ruby-doc.org/stdlib-2.5.3/libdoc/base64/rdoc/Base64.html