### PR TITLE
fix method_missing not having the correct signature

### DIFF
--- a/lib/appium_lib_core/patch.rb
+++ b/lib/appium_lib_core/patch.rb
@@ -28,7 +28,7 @@ module Appium
       #   e.value
       #   e.resource_id # call `e.attribute "resource-id"`
       #
-      def method_missing(method_name)
+      def method_missing(method_name, *args, &block)
         ignore_list = [:to_hash]
         return if ignore_list.include? method_name
 


### PR DESCRIPTION
While I was trying to run to_yaml on a hash containing an appium element, an error was raised,
since the class is missing a `encode_with` method.

Since the method_missing method itself has the wrong signature, it failed actually with wrong number of arguments.

This PR fixes the signature of method_missing inside patch.rb

FYI I ended up adding encode_with as well:

```ruby
def encode_with coder
  coder['name'] = name
end
```