### PR TITLE
Donotsend unused value start activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Read `release_notes.md` for commit level details.
 ### Enhancements
 
 ### Bug fixes
+- Stop sending blank value in `start_activity`
 
 ### Deprecations
 

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -303,22 +303,26 @@ module Appium
               def start_activity(opts)
                 raise 'opts must be a hash' unless opts.is_a? Hash
 
+                option = {}
+
                 app_package = opts[:app_package]
                 raise 'app_package is required' unless app_package
 
                 app_activity = opts[:app_activity]
                 raise 'app_activity is required' unless app_activity
 
-                app_wait_package  = opts.fetch(:app_wait_package, '')
-                app_wait_activity = opts.fetch(:app_wait_activity, '')
+                option[:appPackage] = app_package
+                option[:appActivity] = app_activity
+
+                app_wait_package  = opts.fetch(:app_wait_package, nil)
+                app_wait_activity = opts.fetch(:app_wait_activity, nil)
+                option[:appWaitPackage] = app_wait_package if app_wait_package
+                option[:appWaitActivity] = app_wait_activity if app_wait_activity
 
                 unknown_opts = opts.keys - %i(app_package app_activity app_wait_package app_wait_activity)
                 raise "Unknown options #{unknown_opts}" unless unknown_opts.empty?
 
-                execute :start_activity, {}, appPackage: app_package,
-                                             appActivity: app_activity,
-                                             appWaitPackage: app_wait_package,
-                                             appWaitActivity: app_wait_activity
+                execute :start_activity, {}, option
               end
             end
 

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -135,17 +135,15 @@ class AppiumLibCoreTest
         e = @@core.wait { @driver.current_activity }
         assert true, e.include?('Node')
 
-        if @@core.automation_name == :espresso
-          @driver.start_activity app_package: 'io.appium.android.apis', app_activity: '.ApiDemos',
-                                 app_wait_activity: '.ApiDemos'
-        else
-          @driver.start_activity app_package: 'com.android.settings', app_activity: '.Settings',
-                                 app_wait_package: 'com.android.settings', app_wait_activity: '.Settings'
-          e = @@core.wait { @driver.current_activity }
-          assert true, e.include?('Settings')
+        # Espresso cannot launch my root launched activity: https://github.com/appium/appium-espresso-driver/pull/378#discussion_r250034209
+        return if @@core.automation_name == :espresso
 
-          @driver.start_activity app_package: 'io.appium.android.apis', app_activity: '.ApiDemos'
-        end
+        @driver.start_activity app_package: 'com.android.settings', app_activity: '.Settings',
+                               app_wait_package: 'com.android.settings', app_wait_activity: '.Settings'
+        e = @@core.wait { @driver.current_activity }
+        assert true, e.include?('Settings')
+
+        @driver.start_activity app_package: 'io.appium.android.apis', app_activity: '.ApiDemos'
       end
 
       def test_current_package

--- a/test/unit/android/device/mjsonwp/commands_test.rb
+++ b/test/unit/android/device/mjsonwp/commands_test.rb
@@ -217,9 +217,21 @@ class AppiumLibCoreTest
 
           def test_start_activity
             stub_request(:post, "#{SESSION}/appium/device/start_activity")
+              .with(body: { appPackage: 'package', appActivity: 'activity' }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+            @driver.start_activity(app_activity: 'activity', app_package: 'package')
+
+            assert_requested(:post, "#{SESSION}/appium/device/start_activity", times: 1)
+          end
+
+          def test_start_activity_with_wait
+            stub_request(:post, "#{SESSION}/appium/device/start_activity")
+              .with(body: { appPackage: 'package', appActivity: 'activity',
+                            appWaitPackage: 'wait_package', appWaitActivity: 'wait_activity' }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.start_activity(app_activity: 'activity', app_package: 'package')
+            @driver.start_activity(app_activity: 'activity', app_package: 'package',
+                                   app_wait_package: 'wait_package', app_wait_activity: 'wait_activity')
 
             assert_requested(:post, "#{SESSION}/appium/device/start_activity", times: 1)
           end

--- a/test/unit/android/device/w3c/commands_test.rb
+++ b/test/unit/android/device/w3c/commands_test.rb
@@ -218,9 +218,21 @@ class AppiumLibCoreTest
 
           def test_start_activity
             stub_request(:post, "#{SESSION}/appium/device/start_activity")
+              .with(body: { appPackage: 'package', appActivity: 'activity' }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+            @driver.start_activity(app_activity: 'activity', app_package: 'package')
+
+            assert_requested(:post, "#{SESSION}/appium/device/start_activity", times: 1)
+          end
+
+          def test_start_activity_with_wait
+            stub_request(:post, "#{SESSION}/appium/device/start_activity")
+              .with(body: { appPackage: 'package', appActivity: 'activity',
+                            appWaitPackage: 'wait_package', appWaitActivity: 'wait_activity' }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
-            @driver.start_activity(app_activity: 'activity', app_package: 'package')
+            @driver.start_activity(app_activity: 'activity', app_package: 'package',
+                                   app_wait_package: 'wait_package', app_wait_activity: 'wait_activity')
 
             assert_requested(:post, "#{SESSION}/appium/device/start_activity", times: 1)
           end


### PR DESCRIPTION
I noticed ruby send blank values in start activity.
https://github.com/appium/appium-espresso-driver/pull/378

I tested in espresso/uiautomator2