### PR TITLE
set default zero implicit wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Read `release_notes.md` for commit level details.
 
 ## [Unreleased]
 ### Enhancements
+- Breaking changes
+    - Set implicit wait zero by default
+    - Can configure `wait: 20` as `appium_lib` capability to keep the behaviour before this change
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@ All notable changes to this project will be documented in this file.
 Read `release_notes.md` for commit level details.
 
 ## [Unreleased]
+
+This release has a breaking change about an implicit wait.
+Ruby client sets `0` seconds as implicit wait by default from this release since it is the default spec behaviour in WebDriver while Ruby client had set `20` seconds for it.
+
 ### Enhancements
 - Breaking changes
     - Set implicit wait zero by default
-    - Can configure `wait: 20` as `appium_lib` capability to keep the behaviour before this change
+        - Can configure `wait: 20` as `appium_lib` capability to keep the behaviour
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -43,11 +43,12 @@ module Appium
       # @return [String] By default, session id is exported in '/tmp/appium_lib_session'
       attr_reader :export_session_path
 
-      # Default wait time for elements to appear
-      # Returns the default client side wait. 20 seconds is by default.
+      # Default wait time for elements to appear in Appium server side.
+      # Returns the default client side wait. 0 seconds is by default. Users should handle the timeout stuff in user-side.
       # Provide Appium::Drive like { appium_lib: { wait: 30 } }
       # @return [Integer]
       attr_reader :default_wait
+      DEFAULT_IMPLICIT_WAIT = 0
 
       # Appium's server port. 4723 is by default.
       # Provide Appium::Drive like { appium_lib: { port: 8080 } }
@@ -448,7 +449,7 @@ module Appium
       # @private
       def set_appium_lib_specific_values(appium_lib_opts)
         @custom_url ||= appium_lib_opts.fetch :server_url, nil
-        @default_wait = appium_lib_opts.fetch :wait, 20
+        @default_wait = appium_lib_opts.fetch :wait, DEFAULT_IMPLICIT_WAIT
 
         # bump current session id into a particular file
         @export_session = appium_lib_opts.fetch :export_session, false

--- a/test/functional/android/android/mjpeg_server_test.rb
+++ b/test/functional/android/android/mjpeg_server_test.rb
@@ -11,7 +11,7 @@ class AppiumLibCoreTest
       end
 
       def teardown
-        save_reports(@@driver)
+        save_reports(@driver)
         @@core.quit_driver
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,7 +88,7 @@ class AppiumLibCoreTest
         },
         appium_lib: {
           export_session: true,
-          wait: 30,
+          wait: 0,
           wait_timeout: 20,
           wait_interval: 1
         }
@@ -125,7 +125,7 @@ class AppiumLibCoreTest
         },
         appium_lib: {
           export_session: true,
-          wait: 30,
+          wait: 0,
           wait_timeout: 20,
           wait_interval: 1
         }
@@ -244,7 +244,7 @@ class AppiumLibCoreTest
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts/implicit_wait")
-        .with(body: { ms: 30_000 }.to_json)
+        .with(body: { ms: 0 }.to_json)
         .to_return(headers: HEADER, status: 200, body: { value: nil }.to_json)
 
       driver = @core.start_driver
@@ -277,13 +277,13 @@ class AppiumLibCoreTest
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts")
-        .with(body: { implicit: 30_000 }.to_json)
+        .with(body: { implicit: 0 }.to_json)
         .to_return(headers: HEADER, status: 200, body: { value: nil }.to_json)
 
       driver = @core.start_driver
 
       assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-      assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 30_000 }.to_json, times: 1)
+      assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 0 }.to_json, times: 1)
       driver
     end
 
@@ -305,7 +305,7 @@ class AppiumLibCoreTest
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts/implicit_wait")
-        .with(body: { ms: 30_000 }.to_json)
+        .with(body: { ms: 0 }.to_json)
         .to_return(headers: HEADER, status: 200, body: { value: nil }.to_json)
 
       driver = @core.start_driver
@@ -332,13 +332,13 @@ class AppiumLibCoreTest
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts")
-        .with(body: { implicit: 30_000 }.to_json)
+        .with(body: { implicit: 0 }.to_json)
         .to_return(headers: HEADER, status: 200, body: { value: nil }.to_json)
 
       driver = @core.start_driver
 
       assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-      assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 30_000 }.to_json, times: 1)
+      assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 0 }.to_json, times: 1)
       driver
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,7 +88,6 @@ class AppiumLibCoreTest
         },
         appium_lib: {
           export_session: true,
-          wait: 0,
           wait_timeout: 20,
           wait_interval: 1
         }
@@ -121,7 +120,8 @@ class AppiumLibCoreTest
           # chromedriverExecutable: "#{Dir.pwd}/test/functional/app/chromedriver_2.34",
           chromeOptions: {
             args: ['--disable-popup-blocking']
-          }
+          },
+          uiautomator2ServerLaunchTimeout: 60_000 # ms
         },
         appium_lib: {
           export_session: true,
@@ -158,7 +158,6 @@ class AppiumLibCoreTest
         },
         appium_lib: {
           export_session: true,
-          wait: 30,
           wait_timeout: 20,
           wait_interval: 1
         }

--- a/test/unit/android/webdriver/w3c/timeouts_test.rb
+++ b/test/unit/android/webdriver/w3c/timeouts_test.rb
@@ -21,7 +21,7 @@ class AppiumLibCoreTest
 
             @driver.manage.timeouts.implicit_wait = 30
 
-            assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 30_000 }.to_json, times: 2)
+            assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 30_000 }.to_json, times: 1)
           end
 
           def test_get_timeouts

--- a/test/unit/common_test.rb
+++ b/test/unit/common_test.rb
@@ -52,13 +52,13 @@ class AppiumLibCoreTest
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts/implicit_wait")
-          .with(body: { ms: 20_000 }.to_json)
+          .with(body: { ms: 0 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
         driver = ::Appium::Core.for({ caps: CAPS.merge({ forceMjsonwp: true }), appium_lib: {} }).start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-        assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 20_000 }.to_json, times: 1)
+        assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 0 }.to_json, times: 1)
         driver
       end
 
@@ -71,13 +71,13 @@ class AppiumLibCoreTest
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts")
-          .with(body: { implicit: 20_000 }.to_json)
+          .with(body: { implicit: 0 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
         driver = ::Appium::Core.for({ caps: CAPS.merge({ forceMjsonwp: false }), appium_lib: {} }).start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-        assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 20_000 }.to_json, times: 1)
+        assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 0 }.to_json, times: 1)
         driver
       end
 
@@ -110,14 +110,14 @@ class AppiumLibCoreTest
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts/implicit_wait")
-          .with(body: { ms: 20_000 }.to_json)
+          .with(body: { ms: 0 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
         core = ::Appium::Core.for({ caps: http_caps.merge({ forceMjsonwp: true }), appium_lib: {} })
         core.start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-        assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 20_000 }.to_json, times: 1)
+        assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 0 }.to_json, times: 1)
 
         assert_equal 'sauce-storage:test/functional/app/api.apk.zip', core.caps[:app]
       end
@@ -131,13 +131,13 @@ class AppiumLibCoreTest
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts")
-          .with(body: { implicit: 20_000 }.to_json)
+          .with(body: { implicit: 0 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
         driver = ::Appium::Core.for({ caps: CAPS, appium_lib: {} }).start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-        assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 20_000 }.to_json, times: 1)
+        assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 0 }.to_json, times: 1)
         driver
       end
 
@@ -179,14 +179,14 @@ class AppiumLibCoreTest
           .to_return(headers: Mock::HEADER, status: 200, body: response)
 
         stub_request(:post, "#{Mock::SESSION}/timeouts")
-          .with(body: { implicit: 20_000 }.to_json)
+          .with(body: { implicit: 0 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
         core = ::Appium::Core.for({ caps: http_caps, appium_lib: {} })
         core.start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-        assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 20_000 }.to_json, times: 1)
+        assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 0 }.to_json, times: 1)
 
         assert_equal 'http://example.com/test.apk.zip', core.caps[:app]
       end

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -71,7 +71,7 @@ class AppiumLibCoreTest
     end
 
     def test_default_wait
-      assert_equal 30, @core.default_wait
+      assert_equal 0, @core.default_wait
     end
 
     def test_default_timeout_for_http_client


### PR DESCRIPTION
Or remove set timeout by default in ruby_lib_core. Sets it in the ruby_lib side.
Otherwise, this change will be breaking change.

Will merge and consider when we introduce another breaking changes