### PR TITLE
Experimental add direct host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Read `release_notes.md` for commit level details.
 
 ## [Unreleased]
 ### Enhancements
+- [Experimental] Add `direct_connect` capability for the Ruby client in order to handle `directConnect` capability in a create session response by Appium server
+    - Update http client following `directConnectProtocol`, `directConnectHost`, `directConnectPort` and `directConnectPath`
+      if `direct_connect` capability for ruby_lib_core is `true`
+    - This will resolve a performance issue if a user has a proxy server to handle requests from client to Appium server.
+      With this feature, the user can send requests directly to the Appium server after create session skipping the proxy server.
+      ```
+      # create session
+      client <---> proxy server <---> appium server <> devices
+      # Following requests after the create session
+      client <----------------------> appium server <> devices
+      ```
 
 ### Bug fixes
 - Fix potential override of `AppManagement#background_app`

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -38,7 +38,7 @@ module Appium
         end
 
         # Can change target URL, custom URL
-        def sending_request_to(protocol:, host:, port:, path:)
+        def update_sending_request_to(protocol:, host:, port:, path:)
           @bridge.http.update_sending_request_to(scheme: protocol,
                                                  host: host,
                                                  port: port,

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -37,7 +37,16 @@ module Appium
           @bridge.dialect
         end
 
-        # Can change target URL, custom URL
+        # Update `server_url` and HTTP clients following this arguments, protocol, host, port and path.
+        # After this method, `@bridge.http` will be a new instance following them instead of `server_url` which is
+        # set before creating session.
+        #
+        # @example
+        #
+        #     driver = core.start_driver server_url: 'http://example1.com:8000/wd/hub # @bridge.http is for `http://example1.com:8000/wd/hub/`
+        #     driver.update_sending_request_to protocol: 'https', host: 'example2.com', port: 9000, path: '/wd/hub'
+        #     driver.manage.timeouts.implicit_wait = 10 # @bridge.http is for `https://example2.com:9000/wd/hub/`
+        #
         def update_sending_request_to(protocol:, host:, port:, path:)
           @bridge.http.update_sending_request_to(scheme: protocol,
                                                  host: host,

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -37,6 +37,14 @@ module Appium
           @bridge.dialect
         end
 
+        # Can change target URL, custom URL
+        def sending_request_to(protocol:, host:, port:, path:)
+          @bridge.http.update_sending_request_to(scheme: protocol,
+                                                 host: host,
+                                                 port: port,
+                                                 path: path)
+        end
+
         ### Methods for Appium
 
         # Lock the device

--- a/lib/appium_lib_core/common/base/http_default.rb
+++ b/lib/appium_lib_core/common/base/http_default.rb
@@ -25,7 +25,7 @@ module Appium
           def update_sending_request_to(scheme:, host:, port:, path:)
             return @server_url unless validate_url_param(scheme, host, port, path)
 
-            # Add / if they does not have
+            # Add / if `path` does not have it
             path = path.start_with?('/') ? path : "/#{path}"
             path = path.end_with?('/') ? path : "#{path}/"
 

--- a/lib/appium_lib_core/common/base/http_default.rb
+++ b/lib/appium_lib_core/common/base/http_default.rb
@@ -25,6 +25,8 @@ module Appium
           def update_sending_request_to(scheme:, host:, port:, path:)
             return @server_url unless validate_url_param(scheme, host, port, path)
 
+            Logger.debug("[experimental] This feature, #{__method__}, is an experimental")
+
             # Add / if `path` does not have it
             path = path.start_with?('/') ? path : "/#{path}"
             path = path.end_with?('/') ? path : "#{path}/"

--- a/lib/appium_lib_core/common/base/http_default.rb
+++ b/lib/appium_lib_core/common/base/http_default.rb
@@ -12,6 +12,35 @@ module Appium
               "appium/ruby_lib_core/#{VERSION} (#{::Selenium::WebDriver::Remote::Http::Common::DEFAULT_HEADERS['User-Agent']})"
           }.freeze
 
+          # Update `server_url` to.
+          # Set `@http` as nil to re-create http client for the server_url
+          # @private
+          #
+          # @param [string] scheme: A scheme to update server_url to
+          # @param [string] host: A host to update server_url to
+          # @param [string|integer] port: A port number to update server_url to
+          # @param [string] path: A path to update server_url to
+          #
+          # @return [URI] An instance of URI updated to. Returns default `server_url` if some of arguments are `nil`
+          def update_sending_request_to(scheme:, host:, port:, path:)
+            return @server_url unless validate_url_param(scheme, host, port, path)
+
+            # Add / if they does not have
+            path = path.start_with?('/') ? path : "/#{path}"
+            path = path.end_with?('/') ? path : "#{path}/"
+
+            @http = nil
+            @server_url = URI.parse "#{scheme}://#{host}:#{port}#{path}"
+          end
+
+          private
+
+          def validate_url_param(scheme, host, port, path)
+            !(scheme.nil? || host.nil? || port.nil? || path.nil?)
+          end
+
+          public
+
           # override to use default header
           # https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/remote/http/common.rb#L46
           def call(verb, url, command_hash)

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -244,6 +244,13 @@ module Appium
                                                      url: @custom_url,
                                                      listener: @listener)
 
+          if @direct_connect
+            @driver.sending_request_to(protocol: @driver.capabilities['directConnectProtocol'],
+                                       host: @driver.capabilities['directConnectHost'],
+                                       port: @driver.capabilities['directConnectPort'],
+                                       path: @driver.capabilities['directConnectPath'])
+          end
+
           # export session
           write_session_id(@driver.session_id, @export_session_path) if @export_session
         rescue Errno::ECONNREFUSED
@@ -453,6 +460,8 @@ module Appium
         # bump current session id into a particular file
         @export_session = appium_lib_opts.fetch :export_session, false
         @export_session_path = appium_lib_opts.fetch :export_session_path, default_tmp_appium_lib_session
+
+        @direct_connect = appium_lib_opts.fetch :direct_access, false
 
         @port = appium_lib_opts.fetch :port, DEFAULT_APPIUM_PORT
 

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -245,10 +245,10 @@ module Appium
                                                      listener: @listener)
 
           if @direct_connect
-            @driver.sending_request_to(protocol: @driver.capabilities['directConnectProtocol'],
-                                       host: @driver.capabilities['directConnectHost'],
-                                       port: @driver.capabilities['directConnectPort'],
-                                       path: @driver.capabilities['directConnectPath'])
+            @driver.update_sending_request_to(protocol: @driver.capabilities['directConnectProtocol'],
+                                              host: @driver.capabilities['directConnectHost'],
+                                              port: @driver.capabilities['directConnectPort'],
+                                              path: @driver.capabilities['directConnectPath'])
           end
 
           # export session

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -75,6 +75,16 @@ module Appium
       # @return [Appium::Core::Base::Driver]
       attr_reader :driver
 
+      # [Experimental feature]
+      # Enable an experimental feature updating Appium HTTP client following `directConnectProtocol`, `directConnectHost`,
+      # `directConnectPort` and `directConnectPath` after session creation if the server returns them as a part of the response
+      # capability in _create session_.
+      #
+      # Ignore them if this parameter is `false`. Defaults to false.
+      #
+      # @return [Bool]
+      attr_reader :direct_connect
+
       # Creates a new global driver and extend particular methods to `target`
       # @param [Class] target Extend particular methods to this target.
       # @param [Hash] opts A options include capabilities for the Appium Server and for the client.

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -79,6 +79,23 @@ class AppiumLibCoreTest
 
       assert_equal 999_999, @core.http_client.open_timeout
       assert_equal 999_999, @core.http_client.read_timeout
+      uri = @driver.send(:bridge).http.send(:server_url)
+      assert_equal 'http', uri.scheme
+      assert_equal '127.0.0.1', uri.host
+      assert_equal 4723, uri.port
+      assert_equal '/wd/hub/', uri.path
+    end
+
+    def test_default_timeout_for_http_client_with_direct
+      driver = android_mock_create_session_w3c_direct(::Appium::Core.for(Caps.android_direct))
+
+      assert_equal 999_999, driver.send(:bridge).http.open_timeout
+      assert_equal 999_999, driver.send(:bridge).http.read_timeout
+      uri = driver.send(:bridge).http.send(:server_url)
+      assert_equal 'http', uri.scheme
+      assert_equal 'localhost', uri.host
+      assert_equal 8888, uri.port
+      assert_equal '/wd/hub/', uri.path
     end
 
     # https://www.w3.org/TR/webdriver1/

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -80,6 +80,7 @@ class AppiumLibCoreTest
       assert_equal 999_999, @core.http_client.open_timeout
       assert_equal 999_999, @core.http_client.read_timeout
       uri = @driver.send(:bridge).http.send(:server_url)
+      assert !@core.direct_connect
       assert_equal 'http', uri.scheme
       assert_equal '127.0.0.1', uri.host
       assert_equal 4723, uri.port
@@ -87,11 +88,13 @@ class AppiumLibCoreTest
     end
 
     def test_default_timeout_for_http_client_with_direct
-      driver = android_mock_create_session_w3c_direct(::Appium::Core.for(Caps.android_direct))
+      core = ::Appium::Core.for(Caps.android_direct)
+      driver = android_mock_create_session_w3c_direct(core)
 
       assert_equal 999_999, driver.send(:bridge).http.open_timeout
       assert_equal 999_999, driver.send(:bridge).http.read_timeout
       uri = driver.send(:bridge).http.send(:server_url)
+      assert core.direct_connect
       assert_equal 'http', uri.scheme
       assert_equal 'localhost', uri.host
       assert_equal 8888, uri.port


### PR DESCRIPTION
This is an experimental feature to improve requests peformance in a particular case.

If a server returns `directConnectProtocol`, `directConnectHost`, `directConnectPort` and `directConnectPath` as a part of the response of create session, Ruby client send following requests to them.
This feature improves performance if a user handles requests via proxy server between clients to Appium servers. In this context, the proxy server is similar to SeleniumGrid.

```
# via proxy server in session creation
client <--> proxy server <---> appium server <-> devices
                                             `-> appium server <-> devices
```

```
# communicate directly after the session creation
client <--------> appium server <-> devices
                   `---> appium server <-> devices
```

This idea was discussed with @jlipps 