### PR TITLE
Bump target rubyversion 2.3 rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,8 @@ Style/NumericPredicate:
 Naming/AccessorMethodName:
   Enabled: false
 Naming/MemoizedInstanceVariableName:
-  Enabled: false
+  Enabled: true
+  Exclude:
+    - test/**/*
 Layout/RescueEnsureAlignment:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Style/BracesAroundHashParameters:
   Enabled: false
 Style/SymbolArray:
   Enabled: false
+# TODO: will remove after stopping support 2.2
 Style/NumericPredicate:
   Enabled: false
 Naming/AccessorMethodName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 Metrics/LineLength:
   Max: 128
 Metrics/MethodLength:
@@ -27,6 +27,8 @@ Style/PercentLiteralDelimiters:
 Style/BracesAroundHashParameters:
   Enabled: false
 Style/SymbolArray:
+  Enabled: false
+Style/NumericPredicate:
   Enabled: false
 Naming/AccessorMethodName:
   Enabled: false

--- a/lib/appium_lib_core.rb
+++ b/lib/appium_lib_core.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'selenium-webdriver'
 
 require_relative 'appium_lib_core/version'

--- a/lib/appium_lib_core/android.rb
+++ b/lib/appium_lib_core/android.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # loaded in common/driver.rb
 require_relative 'android/device'
 require_relative 'android/uiautomator1/bridge'

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'device/emulator'
 require_relative 'device/clipboard'
 require_relative 'device/network'

--- a/lib/appium_lib_core/android/device/auth_finger_print.rb
+++ b/lib/appium_lib_core/android/device/auth_finger_print.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/device/clipboard.rb
+++ b/lib/appium_lib_core/android/device/clipboard.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'base64'
 
 module Appium

--- a/lib/appium_lib_core/android/device/emulator.rb
+++ b/lib/appium_lib_core/android/device/emulator.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/device/network.rb
+++ b/lib/appium_lib_core/android/device/network.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/device/performance.rb
+++ b/lib/appium_lib_core/android/device/performance.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/device/screen.rb
+++ b/lib/appium_lib_core/android/device/screen.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/espresso/bridge.rb
+++ b/lib/appium_lib_core/android/espresso/bridge.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/uiautomator1/bridge.rb
+++ b/lib/appium_lib_core/android/uiautomator1/bridge.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/uiautomator2/bridge.rb
+++ b/lib/appium_lib_core/android/uiautomator2/bridge.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android/uiautomator2/device.rb
+++ b/lib/appium_lib_core/android/uiautomator2/device.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'device/battery'
 
 module Appium

--- a/lib/appium_lib_core/android/uiautomator2/device/battery.rb
+++ b/lib/appium_lib_core/android/uiautomator2/device/battery.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Android

--- a/lib/appium_lib_core/android_espresso.rb
+++ b/lib/appium_lib_core/android_espresso.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # loaded in common/driver.rb
 require_relative 'android/device'
 require_relative 'android/espresso/bridge'

--- a/lib/appium_lib_core/android_uiautomator2.rb
+++ b/lib/appium_lib_core/android_uiautomator2.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # loaded in common/driver.rb
 require_relative 'android/device'
 

--- a/lib/appium_lib_core/common.rb
+++ b/lib/appium_lib_core/common.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'common/logger'
 require_relative 'common/error'
 require_relative 'common/log'

--- a/lib/appium_lib_core/common/base.rb
+++ b/lib/appium_lib_core/common/base.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'device/device_lock'
 require_relative 'device/keyboard'
 require_relative 'device/ime_actions'

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -1,9 +1,23 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base
       class Bridge < ::Selenium::WebDriver::Remote::Bridge
         # Prefix for extra capability defined by W3C
-        APPIUM_PREFIX = 'appium:'.freeze
+        APPIUM_PREFIX = 'appium:'
 
         # TODO: Remove the forceMjsonwp after Appium server won't need it
         FORCE_MJSONWP = :forceMjsonwp

--- a/lib/appium_lib_core/common/base/bridge/mjsonwp.rb
+++ b/lib/appium_lib_core/common/base/bridge/mjsonwp.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/base/bridge/w3c.rb
+++ b/lib/appium_lib_core/common/base/bridge/w3c.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/base/capabilities.rb
+++ b/lib/appium_lib_core/common/base/capabilities.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/base/command.rb
+++ b/lib/appium_lib_core/common/base/command.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -174,7 +174,7 @@ module Appium
         #   @driver.settings.update('allowInvisibleElements': true)
         #
         def settings
-          @driver_settings ||= DriverSettings.new(@bridge)
+          @driver_settings ||= DriverSettings.new(@bridge) # rubocop:disable Naming/MemoizedInstanceVariableName
         end
 
         # Get appium Settings for current test session.
@@ -244,7 +244,7 @@ module Appium
         #   @driver.ime.deactivate #=> Deactivate current IME engine
         #
         def ime
-          @device_ime ||= DeviceIME.new(@bridge)
+          @device_ime ||= DeviceIME.new(@bridge) # rubocop:disable Naming/MemoizedInstanceVariableName
         end
 
         # Android only. Make an engine that is available active.

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'base64'
 require_relative 'search_context'
 require_relative 'screenshot'

--- a/lib/appium_lib_core/common/base/http_default.rb
+++ b/lib/appium_lib_core/common/base/http_default.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative '../../version'
 
 module Appium

--- a/lib/appium_lib_core/common/base/platform.rb
+++ b/lib/appium_lib_core/common/base/platform.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/base/screenshot.rb
+++ b/lib/appium_lib_core/common/base/screenshot.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/base/search_context.rb
+++ b/lib/appium_lib_core/common/base/search_context.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/command.rb
+++ b/lib/appium_lib_core/common/command.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'base/command'
 require_relative 'command/common'
 require_relative 'command/mjsonwp'

--- a/lib/appium_lib_core/common/command/common.rb
+++ b/lib/appium_lib_core/common/command/common.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # rubocop:disable Layout/AlignHash
 module Appium
   module Core
@@ -6,82 +20,82 @@ module Appium
       # Some commands differ for each driver.
       COMMAND = {
         # common
-        available_contexts:         [:get,  'session/:session_id/contexts'.freeze],
-        set_context:                [:post, 'session/:session_id/context'.freeze],
-        current_context:            [:get,  'session/:session_id/context'.freeze],
+        available_contexts:         [:get,  'session/:session_id/contexts'],
+        set_context:                [:post, 'session/:session_id/context'],
+        current_context:            [:get,  'session/:session_id/context'],
 
-        touch_actions:              [:post, 'session/:session_id/touch/perform'.freeze],
-        multi_touch:                [:post, 'session/:session_id/touch/multi/perform'.freeze],
+        touch_actions:              [:post, 'session/:session_id/touch/perform'],
+        multi_touch:                [:post, 'session/:session_id/touch/multi/perform'],
 
-        set_immediate_value:        [:post, 'session/:session_id/appium/element/:id/value'.freeze],
-        replace_value:              [:post, 'session/:session_id/appium/element/:id/replace_value'.freeze],
+        set_immediate_value:        [:post, 'session/:session_id/appium/element/:id/value'],
+        replace_value:              [:post, 'session/:session_id/appium/element/:id/replace_value'],
 
-        launch_app:                 [:post, 'session/:session_id/appium/app/launch'.freeze],
-        close_app:                  [:post, 'session/:session_id/appium/app/close'.freeze],
-        reset:                      [:post, 'session/:session_id/appium/app/reset'.freeze],
-        background_app:             [:post, 'session/:session_id/appium/app/background'.freeze],
-        app_strings:                [:post, 'session/:session_id/appium/app/strings'.freeze],
+        launch_app:                 [:post, 'session/:session_id/appium/app/launch'],
+        close_app:                  [:post, 'session/:session_id/appium/app/close'],
+        reset:                      [:post, 'session/:session_id/appium/app/reset'],
+        background_app:             [:post, 'session/:session_id/appium/app/background'],
+        app_strings:                [:post, 'session/:session_id/appium/app/strings'],
 
-        device_locked?:             [:post, 'session/:session_id/appium/device/is_locked'.freeze],
-        unlock:                     [:post, 'session/:session_id/appium/device/unlock'.freeze],
-        lock:                       [:post, 'session/:session_id/appium/device/lock'.freeze],
-        device_time:                [:get,  'session/:session_id/appium/device/system_time'.freeze],
-        install_app:                [:post, 'session/:session_id/appium/device/install_app'.freeze],
-        remove_app:                 [:post, 'session/:session_id/appium/device/remove_app'.freeze],
-        app_installed?:             [:post, 'session/:session_id/appium/device/app_installed'.freeze],
-        activate_app:               [:post, 'session/:session_id/appium/device/activate_app'.freeze],
-        terminate_app:              [:post, 'session/:session_id/appium/device/terminate_app'.freeze],
-        app_state:                  [:post, 'session/:session_id/appium/device/app_state'.freeze],
-        shake:                      [:post, 'session/:session_id/appium/device/shake'.freeze],
-        hide_keyboard:              [:post, 'session/:session_id/appium/device/hide_keyboard'.freeze],
-        press_keycode:              [:post, 'session/:session_id/appium/device/press_keycode'.freeze],
-        long_press_keycode:         [:post, 'session/:session_id/appium/device/long_press_keycode'.freeze],
+        device_locked?:             [:post, 'session/:session_id/appium/device/is_locked'],
+        unlock:                     [:post, 'session/:session_id/appium/device/unlock'],
+        lock:                       [:post, 'session/:session_id/appium/device/lock'],
+        device_time:                [:get,  'session/:session_id/appium/device/system_time'],
+        install_app:                [:post, 'session/:session_id/appium/device/install_app'],
+        remove_app:                 [:post, 'session/:session_id/appium/device/remove_app'],
+        app_installed?:             [:post, 'session/:session_id/appium/device/app_installed'],
+        activate_app:               [:post, 'session/:session_id/appium/device/activate_app'],
+        terminate_app:              [:post, 'session/:session_id/appium/device/terminate_app'],
+        app_state:                  [:post, 'session/:session_id/appium/device/app_state'],
+        shake:                      [:post, 'session/:session_id/appium/device/shake'],
+        hide_keyboard:              [:post, 'session/:session_id/appium/device/hide_keyboard'],
+        press_keycode:              [:post, 'session/:session_id/appium/device/press_keycode'],
+        long_press_keycode:         [:post, 'session/:session_id/appium/device/long_press_keycode'],
         # keyevent is only for Selendroid
-        keyevent:                   [:post, 'session/:session_id/appium/device/keyevent'.freeze],
-        push_file:                  [:post, 'session/:session_id/appium/device/push_file'.freeze],
-        pull_file:                  [:post, 'session/:session_id/appium/device/pull_file'.freeze],
-        pull_folder:                [:post, 'session/:session_id/appium/device/pull_folder'.freeze],
-        get_clipboard:              [:post, 'session/:session_id/appium/device/get_clipboard'.freeze],
-        set_clipboard:              [:post, 'session/:session_id/appium/device/set_clipboard'.freeze],
-        finger_print:               [:post, 'session/:session_id/appium/device/finger_print'.freeze],
-        get_settings:               [:get,  'session/:session_id/appium/settings'.freeze],
-        update_settings:            [:post, 'session/:session_id/appium/settings'.freeze],
-        stop_recording_screen:      [:post, 'session/:session_id/appium/stop_recording_screen'.freeze],
-        start_recording_screen:     [:post, 'session/:session_id/appium/start_recording_screen'.freeze],
-        compare_images:             [:post, 'session/:session_id/appium/compare_images'.freeze],
-        is_keyboard_shown:          [:get,  'session/:session_id/appium/device/is_keyboard_shown'.freeze]
+        keyevent:                   [:post, 'session/:session_id/appium/device/keyevent'],
+        push_file:                  [:post, 'session/:session_id/appium/device/push_file'],
+        pull_file:                  [:post, 'session/:session_id/appium/device/pull_file'],
+        pull_folder:                [:post, 'session/:session_id/appium/device/pull_folder'],
+        get_clipboard:              [:post, 'session/:session_id/appium/device/get_clipboard'],
+        set_clipboard:              [:post, 'session/:session_id/appium/device/set_clipboard'],
+        finger_print:               [:post, 'session/:session_id/appium/device/finger_print'],
+        get_settings:               [:get,  'session/:session_id/appium/settings'],
+        update_settings:            [:post, 'session/:session_id/appium/settings'],
+        stop_recording_screen:      [:post, 'session/:session_id/appium/stop_recording_screen'],
+        start_recording_screen:     [:post, 'session/:session_id/appium/start_recording_screen'],
+        compare_images:             [:post, 'session/:session_id/appium/compare_images'],
+        is_keyboard_shown:          [:get,  'session/:session_id/appium/device/is_keyboard_shown']
       }.freeze
 
       COMMAND_ANDROID = {
-        open_notifications:         [:post, 'session/:session_id/appium/device/open_notifications'.freeze],
-        toggle_airplane_mode:       [:post, 'session/:session_id/appium/device/toggle_airplane_mode'.freeze],
-        start_activity:             [:post, 'session/:session_id/appium/device/start_activity'.freeze],
-        current_activity:           [:get,  'session/:session_id/appium/device/current_activity'.freeze],
-        current_package:            [:get,  'session/:session_id/appium/device/current_package'.freeze],
-        get_system_bars:            [:get,  'session/:session_id/appium/device/system_bars'.freeze],
-        get_display_density:        [:get,  'session/:session_id/appium/device/display_density'.freeze],
-        toggle_wifi:                [:post, 'session/:session_id/appium/device/toggle_wifi'.freeze],
-        toggle_data:                [:post, 'session/:session_id/appium/device/toggle_data'.freeze],
-        toggle_location_services:   [:post, 'session/:session_id/appium/device/toggle_location_services'.freeze],
-        end_coverage:               [:post, 'session/:session_id/appium/app/end_test_coverage'.freeze],
-        get_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'.freeze],
-        get_performance_data:       [:post, 'session/:session_id/appium/getPerformanceData'.freeze],
-        get_network_connection:     [:get,  'session/:session_id/network_connection'.freeze], # defined also in OSS
-        set_network_connection:     [:post, 'session/:session_id/network_connection'.freeze], # defined also in OSS
+        open_notifications:         [:post, 'session/:session_id/appium/device/open_notifications'],
+        toggle_airplane_mode:       [:post, 'session/:session_id/appium/device/toggle_airplane_mode'],
+        start_activity:             [:post, 'session/:session_id/appium/device/start_activity'],
+        current_activity:           [:get,  'session/:session_id/appium/device/current_activity'],
+        current_package:            [:get,  'session/:session_id/appium/device/current_package'],
+        get_system_bars:            [:get,  'session/:session_id/appium/device/system_bars'],
+        get_display_density:        [:get,  'session/:session_id/appium/device/display_density'],
+        toggle_wifi:                [:post, 'session/:session_id/appium/device/toggle_wifi'],
+        toggle_data:                [:post, 'session/:session_id/appium/device/toggle_data'],
+        toggle_location_services:   [:post, 'session/:session_id/appium/device/toggle_location_services'],
+        end_coverage:               [:post, 'session/:session_id/appium/app/end_test_coverage'],
+        get_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'],
+        get_performance_data:       [:post, 'session/:session_id/appium/getPerformanceData'],
+        get_network_connection:     [:get,  'session/:session_id/network_connection'], # defined also in OSS
+        set_network_connection:     [:post, 'session/:session_id/network_connection'], # defined also in OSS
 
         # only emulator
-        send_sms:                   [:post, 'session/:session_id/appium/device/send_sms'.freeze],
-        gsm_call:                   [:post, 'session/:session_id/appium/device/gsm_call'.freeze],
-        gsm_signal:                 [:post, 'session/:session_id/appium/device/gsm_signal'.freeze],
-        gsm_voice:                  [:post, 'session/:session_id/appium/device/gsm_voice'.freeze],
-        set_network_speed:          [:post, 'session/:session_id/appium/device/network_speed'.freeze],
-        set_power_capacity:         [:post, 'session/:session_id/appium/device/power_capacity'.freeze],
-        set_power_ac:               [:post, 'session/:session_id/appium/device/power_ac'.freeze]
+        send_sms:                   [:post, 'session/:session_id/appium/device/send_sms'],
+        gsm_call:                   [:post, 'session/:session_id/appium/device/gsm_call'],
+        gsm_signal:                 [:post, 'session/:session_id/appium/device/gsm_signal'],
+        gsm_voice:                  [:post, 'session/:session_id/appium/device/gsm_voice'],
+        set_network_speed:          [:post, 'session/:session_id/appium/device/network_speed'],
+        set_power_capacity:         [:post, 'session/:session_id/appium/device/power_capacity'],
+        set_power_ac:               [:post, 'session/:session_id/appium/device/power_ac']
       }.freeze
 
       COMMAND_IOS = {
-        touch_id:                   [:post, 'session/:session_id/appium/simulator/touch_id'.freeze],
-        toggle_touch_id_enrollment: [:post, 'session/:session_id/appium/simulator/toggle_touch_id_enrollment'.freeze]
+        touch_id:                   [:post, 'session/:session_id/appium/simulator/touch_id'],
+        toggle_touch_id_enrollment: [:post, 'session/:session_id/appium/simulator/toggle_touch_id_enrollment']
       }.freeze
 
       COMMANDS = {}.merge(COMMAND).merge(COMMAND_ANDROID).merge(COMMAND_IOS).freeze

--- a/lib/appium_lib_core/common/command/mjsonwp.rb
+++ b/lib/appium_lib_core/common/command/mjsonwp.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # rubocop:disable Layout/AlignHash
 module Appium
   module Core
@@ -6,7 +20,7 @@ module Appium
         COMMANDS = ::Appium::Core::Commands::COMMANDS.merge(::Appium::Core::Base::Commands::OSS).merge(
           {
             # W3C already has.
-            take_element_screenshot:    [:get, 'session/:session_id/element/:id/screenshot'.freeze]
+            take_element_screenshot:    [:get, 'session/:session_id/element/:id/screenshot']
           }
         ).freeze
       end # module MJSONWP

--- a/lib/appium_lib_core/common/command/w3c.rb
+++ b/lib/appium_lib_core/common/command/w3c.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # rubocop:disable Layout/AlignHash
 module Appium
   module Core
@@ -7,34 +21,34 @@ module Appium
           {
             # ::Appium::Core::Base::Commands::OSS has the following commands and Appium also use them.
             # Delegated to ::Appium::Core::Base::Commands::OSS commands
-            status:                    [:get, 'status'.freeze], # https://w3c.github.io/webdriver/#dfn-status
-            is_element_displayed:      [:get, 'session/:session_id/element/:id/displayed'.freeze], # hint: https://w3c.github.io/webdriver/#element-displayedness
+            status:                    [:get, 'status'], # https://w3c.github.io/webdriver/#dfn-status
+            is_element_displayed:      [:get, 'session/:session_id/element/:id/displayed'], # hint: https://w3c.github.io/webdriver/#element-displayedness
 
-            get_timeouts:              [:get, 'session/:session_id/timeouts'.freeze], # https://w3c.github.io/webdriver/#get-timeouts
+            get_timeouts:              [:get, 'session/:session_id/timeouts'], # https://w3c.github.io/webdriver/#get-timeouts
 
             # Add OSS commands to W3C commands. We can remove them if we would like to remove them from W3C module.
             ### Session capability
-            get_capabilities:          [:get, 'session/:session_id'.freeze],
+            get_capabilities:          [:get, 'session/:session_id'],
 
             ### rotatable
-            get_screen_orientation:    [:get, 'session/:session_id/orientation'.freeze],
-            set_screen_orientation:    [:post, 'session/:session_id/orientation'.freeze],
+            get_screen_orientation:    [:get, 'session/:session_id/orientation'],
+            set_screen_orientation:    [:post, 'session/:session_id/orientation'],
 
-            get_location:              [:get, 'session/:session_id/location'.freeze],
-            set_location:              [:post, 'session/:session_id/location'.freeze],
+            get_location:              [:get, 'session/:session_id/location'],
+            set_location:              [:post, 'session/:session_id/location'],
 
             ### For IME
-            ime_get_available_engines: [:get,  'session/:session_id/ime/available_engines'.freeze],
-            ime_get_active_engine:     [:get,  'session/:session_id/ime/active_engine'.freeze],
-            ime_is_activated:          [:get,  'session/:session_id/ime/activated'.freeze],
-            ime_deactivate:            [:post, 'session/:session_id/ime/deactivate'.freeze],
-            ime_activate_engine:       [:post, 'session/:session_id/ime/activate'.freeze],
+            ime_get_available_engines: [:get,  'session/:session_id/ime/available_engines'],
+            ime_get_active_engine:     [:get,  'session/:session_id/ime/active_engine'],
+            ime_is_activated:          [:get,  'session/:session_id/ime/activated'],
+            ime_deactivate:            [:post, 'session/:session_id/ime/deactivate'],
+            ime_activate_engine:       [:post, 'session/:session_id/ime/activate'],
 
-            send_keys_to_active_element: [:post, 'session/:session_id/keys'.freeze],
+            send_keys_to_active_element: [:post, 'session/:session_id/keys'],
 
             ### Logs
-            get_available_log_types:   [:get, 'session/:session_id/log/types'.freeze],
-            get_log:                   [:post, 'session/:session_id/log'.freeze]
+            get_available_log_types:   [:get, 'session/:session_id/log/types'],
+            get_log:                   [:post, 'session/:session_id/log']
           }
         ).freeze
       end # module W3C

--- a/lib/appium_lib_core/common/device/app_management.rb
+++ b/lib/appium_lib_core/common/device/app_management.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/app_state.rb
+++ b/lib/appium_lib_core/common/device/app_state.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/battery_status.rb
+++ b/lib/appium_lib_core/common/device/battery_status.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/clipboard_content_type.rb
+++ b/lib/appium_lib_core/common/device/clipboard_content_type.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/context.rb
+++ b/lib/appium_lib_core/common/device/context.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/device.rb
+++ b/lib/appium_lib_core/common/device/device.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/device_lock.rb
+++ b/lib/appium_lib_core/common/device/device_lock.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/file_management.rb
+++ b/lib/appium_lib_core/common/device/file_management.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'base64'
 
 module Appium

--- a/lib/appium_lib_core/common/device/image_comparison.rb
+++ b/lib/appium_lib_core/common/device/image_comparison.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'base64'
 
 module Appium

--- a/lib/appium_lib_core/common/device/ime_actions.rb
+++ b/lib/appium_lib_core/common/device/ime_actions.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/keyboard.rb
+++ b/lib/appium_lib_core/common/device/keyboard.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/keyevent.rb
+++ b/lib/appium_lib_core/common/device/keyevent.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/screen_record.rb
+++ b/lib/appium_lib_core/common/device/screen_record.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/setting.rb
+++ b/lib/appium_lib_core/common/device/setting.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/device/touch_actions.rb
+++ b/lib/appium_lib_core/common/device/touch_actions.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative '../touch_action/touch_actions'
 require_relative '../touch_action/multi_touch'
 

--- a/lib/appium_lib_core/common/device/value.rb
+++ b/lib/appium_lib_core/common/device/value.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Base

--- a/lib/appium_lib_core/common/error.rb
+++ b/lib/appium_lib_core/common/error.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Error

--- a/lib/appium_lib_core/common/log.rb
+++ b/lib/appium_lib_core/common/log.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     class Logs

--- a/lib/appium_lib_core/common/logger.rb
+++ b/lib/appium_lib_core/common/logger.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'forwardable'
 require 'logger'
 

--- a/lib/appium_lib_core/common/touch_action/multi_touch.rb
+++ b/lib/appium_lib_core/common/touch_action/multi_touch.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     # MultiTouch actions allow for multiple touches to happen at the same time,

--- a/lib/appium_lib_core/common/touch_action/touch_actions.rb
+++ b/lib/appium_lib_core/common/touch_action/touch_actions.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     # Perform a series of gestures, one after another.  Gestures are chained

--- a/lib/appium_lib_core/common/wait.rb
+++ b/lib/appium_lib_core/common/wait.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'wait/timer'
 
 module Appium

--- a/lib/appium_lib_core/common/wait.rb
+++ b/lib/appium_lib_core/common/wait.rb
@@ -60,7 +60,7 @@ module Appium
           end
 
           msg = message_for timeout, message
-          msg << " (#{last_error.message})" if last_error
+          msg += " (#{last_error.message})" if last_error
 
           raise TimeoutError, msg
         end
@@ -105,7 +105,7 @@ module Appium
           end
 
           msg = message_for timeout, message
-          msg << " (#{last_error.message})" if last_error
+          msg += " (#{last_error.message})" if last_error
 
           raise TimeoutError, msg
         end
@@ -114,7 +114,7 @@ module Appium
 
         def message_for(timeout, message)
           msg = "timed out after #{timeout} seconds"
-          msg << ", #{message}" if message
+          msg += ", #{message}" if message
           msg
         end
       end # self

--- a/lib/appium_lib_core/common/wait/timer.rb
+++ b/lib/appium_lib_core/common/wait/timer.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Wait

--- a/lib/appium_lib_core/common/ws/websocket.rb
+++ b/lib/appium_lib_core/common/ws/websocket.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'faye/websocket'
 require 'eventmachine'
 

--- a/lib/appium_lib_core/device.rb
+++ b/lib/appium_lib_core/device.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Device

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'uri'
 
 module Appium

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -328,6 +328,12 @@ module Appium
       #     @core = Appium::Core.for(opts) # create a core driver with `opts` and extend methods into `self`
       #     @driver = @core.start_driver server_url: "http://127.0.0.1:8000/wd/hub"
       #
+      #     # Attach custom HTTP client
+      #     @driver = @core.start_driver server_url: "http://127.0.0.1:8000/wd/hub",
+      #                                  http_client_ops: { http_client: Your:Http:Client.new,
+      #                                                     open_timeout: 1_000,
+      #                                                     read_timeout: 1_000 }
+      #
 
       def start_driver(server_url: nil,
                        http_client_ops: { http_client: nil, open_timeout: 999_999, read_timeout: 999_999 })
@@ -367,7 +373,7 @@ module Appium
       private
 
       def create_http_client(http_client: nil, open_timeout: nil, read_timeout: nil)
-        @http_client ||= http_client || Appium::Core::Base::Http::Default.new
+        @http_client = http_client || Appium::Core::Base::Http::Default.new
 
         # open_timeout and read_timeout are explicit wait.
         @http_client.open_timeout = open_timeout if open_timeout

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -606,7 +606,7 @@ module Appium
 
       # @private
       def write_session_id(session_id, export_path = '/tmp/appium_lib_session')
-        export_path.tr!('/', '\\') if ::Appium::Core::Base.platform.windows?
+        export_path = export_path.tr('/', '\\') if ::Appium::Core::Base.platform.windows?
         File.write(export_path, session_id)
       rescue IOError => e
         ::Appium::Logger.warn e

--- a/lib/appium_lib_core/ios.rb
+++ b/lib/appium_lib_core/ios.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # loaded in common/driver.rb
 require_relative 'ios/device'
 

--- a/lib/appium_lib_core/ios/device.rb
+++ b/lib/appium_lib_core/ios/device.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'device/clipboard'
 
 module Appium

--- a/lib/appium_lib_core/ios/device/clipboard.rb
+++ b/lib/appium_lib_core/ios/device/clipboard.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'base64'
 
 module Appium

--- a/lib/appium_lib_core/ios/uiautomation/bridge.rb
+++ b/lib/appium_lib_core/ios/uiautomation/bridge.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Ios

--- a/lib/appium_lib_core/ios/uiautomation/device.rb
+++ b/lib/appium_lib_core/ios/uiautomation/device.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Ios

--- a/lib/appium_lib_core/ios/uiautomation/patch.rb
+++ b/lib/appium_lib_core/ios/uiautomation/patch.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Ios

--- a/lib/appium_lib_core/ios/xcuitest/bridge.rb
+++ b/lib/appium_lib_core/ios/xcuitest/bridge.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Ios

--- a/lib/appium_lib_core/ios/xcuitest/device.rb
+++ b/lib/appium_lib_core/ios/xcuitest/device.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require_relative 'device/performance'
 require_relative 'device/screen'
 require_relative 'device/battery'

--- a/lib/appium_lib_core/ios/xcuitest/device/battery.rb
+++ b/lib/appium_lib_core/ios/xcuitest/device/battery.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Ios

--- a/lib/appium_lib_core/ios/xcuitest/device/performance.rb
+++ b/lib/appium_lib_core/ios/xcuitest/device/performance.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Ios

--- a/lib/appium_lib_core/ios/xcuitest/device/screen.rb
+++ b/lib/appium_lib_core/ios/xcuitest/device/screen.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
     module Ios

--- a/lib/appium_lib_core/ios_xcuitest.rb
+++ b/lib/appium_lib_core/ios_xcuitest.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # loaded in common/driver.rb
 require_relative 'ios/device'
 

--- a/lib/appium_lib_core/patch.rb
+++ b/lib/appium_lib_core/patch.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # rubocop:disable Style/ClassAndModuleChildren
 module Appium
   module Core

--- a/lib/appium_lib_core/version.rb
+++ b/lib/appium_lib_core/version.rb
@@ -1,6 +1,20 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Appium
   module Core
-    VERSION = '3.0.2'.freeze unless defined? ::Appium::Core::VERSION
-    DATE    = '2019-03-07'.freeze unless defined? ::Appium::Core::DATE
+    VERSION = '3.0.2' unless defined? ::Appium::Core::VERSION
+    DATE    = '2019-03-07' unless defined? ::Appium::Core::DATE
   end
 end

--- a/script/commands.rb
+++ b/script/commands.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'net/http'
 require './lib/appium_lib_core'
 
@@ -44,7 +58,7 @@ module Script
     # @private
     HTTP_METHOD_MATCH = /GET:|POST:|DELETE:|PUT:|PATCH:/.freeze
     # @private
-    WD_HUB_PREFIX_MATCH = "'/wd/hub/".freeze
+    WD_HUB_PREFIX_MATCH = "'/wd/hub/"
 
     # Read routes.js and set the values in @spec_commands
     #

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/android/device_test.rb

--- a/test/functional/android/android/image_comparison_test.rb
+++ b/test/functional/android/android/image_comparison_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/android/image_comparison_test.rb

--- a/test/functional/android/android/mjpeg_server_test.rb
+++ b/test/functional/android/android/mjpeg_server_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/android/android/mjpeg_server_test.rb

--- a/test/functional/android/android/mobile_commands_test.rb
+++ b/test/functional/android/android/mobile_commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/android/mobile_commands_test.rb

--- a/test/functional/android/android/search_context_test.rb
+++ b/test/functional/android/android/search_context_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/android/search_context_test.rb

--- a/test/functional/android/driver_test.rb
+++ b/test/functional/android/driver_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/driver_test.rb

--- a/test/functional/android/driver_test.rb
+++ b/test/functional/android/driver_test.rb
@@ -36,7 +36,7 @@ class AppiumLibCoreTest
 
     def test_platform_version
       # @@core.platform_version #=> [7, 1, 1]
-      assert @@core.platform_version.length > 1
+      assert @@core.platform_version.length => 1
     end
 
     def test_screenshot

--- a/test/functional/android/patch_test.rb
+++ b/test/functional/android/patch_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/patch_test.rb

--- a/test/functional/android/webdriver/create_session_test.rb
+++ b/test/functional/android/webdriver/create_session_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/webdriver/create_session_test.rb

--- a/test/functional/android/webdriver/device_test.rb
+++ b/test/functional/android/webdriver/device_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:android TEST=test/functional/android/webdriver/device_test.rb

--- a/test/functional/android/webdriver/w3c_actions_test.rb
+++ b/test/functional/android/webdriver/w3c_actions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/test/functional/common_w3c_actions.rb
+++ b/test/functional/common_w3c_actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/test/functional/ios/driver_test.rb
+++ b/test/functional/ios/driver_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/ios/driver_test.rb

--- a/test/functional/ios/ios/device_test.rb
+++ b/test/functional/ios/ios/device_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'base64'
 

--- a/test/functional/ios/ios/image_comparison_test.rb
+++ b/test/functional/ios/ios/image_comparison_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'base64'
 

--- a/test/functional/ios/ios/mjpeg_server_test.rb
+++ b/test/functional/ios/ios/mjpeg_server_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/ios/ios/mjpeg_server_test.rb

--- a/test/functional/ios/ios/mobile_commands_test.rb
+++ b/test/functional/ios/ios/mobile_commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/ios/ios/mobile_commands_test.rb

--- a/test/functional/ios/ios/search_context_test.rb
+++ b/test/functional/ios/ios/search_context_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/ios/ios/search_context_test.rb

--- a/test/functional/ios/patch_test.rb
+++ b/test/functional/ios/patch_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/ios/patch_test.rb

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/ios/webdriver/create_session_test.rb

--- a/test/functional/ios/webdriver/device_test.rb
+++ b/test/functional/ios/webdriver/device_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 # $ rake test:func:ios TEST=test/functional/ios/webdriver/device_test.rb

--- a/test/functional/ios/webdriver/device_test.rb
+++ b/test/functional/ios/webdriver/device_test.rb
@@ -162,7 +162,8 @@ class AppiumLibCoreTest
         @@driver.save_screenshot lower_again_image_path
 
         assert File.size(lower_image_path) != File.size(higher_image_path)
-        assert_equal File.size(lower_again_image_path), File.size(lower_image_path)
+        # Image size can differ. (Depends on process to store it)
+        assert_in_delta File.size(lower_again_image_path), File.size(lower_image_path), 500
 
         # make sure the screenshot is png
         assert Base64.strict_encode64(File.read(lower_image_path)).start_with?('iVBOR')

--- a/test/functional/ios/webdriver/w3c_actions_test.rb
+++ b/test/functional/ios/webdriver/w3c_actions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,7 +60,7 @@ class AppiumLibCoreTest
 
   def self.path_of(path)
     path_dup = path.dup
-    path_dup.tr!('/', '\\') if ::Appium::Core::Base.platform.windows?
+    path_dup = path_dup.tr('/', '\\') if ::Appium::Core::Base.platform.windows?
     path_dup
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'simplecov'
 SimpleCov.start
 
@@ -12,7 +26,7 @@ Appium::Logger.level = ::Logger::FATAL # Show Logger logs only they are error
 
 Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new
 
-ROOT_REPORT_PATH = "#{Dir.pwd}/test/report".freeze
+ROOT_REPORT_PATH = "#{Dir.pwd}/test/report"
 START_AT = Time.now.strftime('%Y-%m-%d-%H%M%S').freeze
 
 Dir.mkdir(ROOT_REPORT_PATH) unless Dir.exist? ROOT_REPORT_PATH
@@ -210,7 +224,7 @@ class AppiumLibCoreTest
 
   module Mock
     HEADER = { 'Content-Type' => 'application/json; charset=utf-8', 'Cache-Control' => 'no-cache' }.freeze
-    SESSION = 'http://127.0.0.1:4723/wd/hub/session/1234567890'.freeze
+    SESSION = 'http://127.0.0.1:4723/wd/hub/session/1234567890'
 
     def android_mock_create_session
       response = {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -83,7 +83,7 @@ class AppiumLibCoreTest
 
     # Require a simulator which OS version is 11.4, for example.
     def ios
-      wda_local_port = get_wda_local_port
+      wda_local_port = _wda_local_port
       device_name = parallel? ? "iPhone 8 - #{wda_local_port}" : 'iPhone 8'
 
       {
@@ -120,7 +120,7 @@ class AppiumLibCoreTest
           platformName: :android,
           automationName: ENV['AUTOMATION_NAME_DROID'] || 'uiautomator2',
           app: 'test/functional/app/api.apk.zip',
-          udid: get_udid_name,
+          udid: _udid_name,
           deviceName: 'Android Emulator',
           appPackage: 'io.appium.android.apis',
           appActivity: activity_name || 'io.appium.android.apis.ApiDemos',
@@ -129,7 +129,7 @@ class AppiumLibCoreTest
           resetKeyboard: true,
           disableWindowAnimation: true,
           newCommandTimeout: 300,
-          systemPort: get_system_port,
+          systemPort: _system_port,
           language: 'en',
           locale: 'US',
           adbExecTimeout: 10_000, # 10 sec
@@ -176,14 +176,14 @@ class AppiumLibCoreTest
           # chromedriverExecutable: "#{Dir.pwd}/test/functional/app/chromedriver_2.34",
           # Or `npm install --chromedriver_version="2.24"` and
           # chromedriverUseSystemExecutable: true,
-          udid: get_udid_name,
+          udid: _udid_name,
           deviceName: 'Android Emulator',
           someCapability: 'some_capability',
           unicodeKeyboard: true,
           resetKeyboard: true,
           disableWindowAnimation: true,
           newCommandTimeout: 300,
-          systemPort: get_system_port,
+          systemPort: _system_port,
           language: 'en',
           locale: 'US'
         },
@@ -201,7 +201,7 @@ class AppiumLibCoreTest
 
     private
 
-    def get_wda_local_port
+    def _wda_local_port
       # TEST_ENV_NUMBER is provided by parallel_tests gem
       # The number is '', '2', '3',...
       number = ENV['TEST_ENV_NUMBER'] || ''
@@ -209,13 +209,13 @@ class AppiumLibCoreTest
       [8100, 8101][core_number]
     end
 
-    def get_system_port
+    def _system_port
       number = ENV['TEST_ENV_NUMBER'] || ''
       core_number = number.empty? ? 0 : number.to_i - 1
       [8200, 8201, 8202][core_number]
     end
 
-    def get_udid_name
+    def _udid_name
       number = ENV['TEST_ENV_NUMBER'] || ''
       core_number = number.empty? ? 0 : number.to_i - 1
       %w(emulator-5554 emulator-5556 emulator-5558)[core_number]

--- a/test/unit/android/device/mjsonwp/app_management_test.rb
+++ b/test/unit/android/device/mjsonwp/app_management_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/mjsonwp/commands_test.rb
+++ b/test/unit/android/device/mjsonwp/commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/mjsonwp/contexts_test.rb
+++ b/test/unit/android/device/mjsonwp/contexts_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/mjsonwp/definition_test.rb
+++ b/test/unit/android/device/mjsonwp/definition_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/mjsonwp/device_lock_test.rb
+++ b/test/unit/android/device/mjsonwp/device_lock_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/mjsonwp/image_comparison_test.rb
+++ b/test/unit/android/device/mjsonwp/image_comparison_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/mjsonwp/ime_actions_test.rb
+++ b/test/unit/android/device/mjsonwp/ime_actions_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/mjsonwp/keyboard_test.rb
+++ b/test/unit/android/device/mjsonwp/keyboard_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/mjsonwp/screenshot_test.rb
+++ b/test/unit/android/device/mjsonwp/screenshot_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 require 'base64'

--- a/test/unit/android/device/w3c/app_management_test.rb
+++ b/test/unit/android/device/w3c/app_management_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/commands_test.rb
+++ b/test/unit/android/device/w3c/commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/contexts_test.rb
+++ b/test/unit/android/device/w3c/contexts_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/definition_test.rb
+++ b/test/unit/android/device/w3c/definition_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/device_lock_test.rb
+++ b/test/unit/android/device/w3c/device_lock_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/image_comparison_test.rb
+++ b/test/unit/android/device/w3c/image_comparison_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/ime_actions_test.rb
+++ b/test/unit/android/device/w3c/ime_actions_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/keyboard_test.rb
+++ b/test/unit/android/device/w3c/keyboard_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/device/w3c/screenshot_test.rb
+++ b/test/unit/android/device/w3c/screenshot_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/mjsonwp/actions_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/actions_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/mjsonwp/alerts_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/alerts_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/mjsonwp/commands_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/mjsonwp/timeouts_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/timeouts_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/w3c/actions_test.rb
+++ b/test/unit/android/webdriver/w3c/actions_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/w3c/alerts_test.rb
+++ b/test/unit/android/webdriver/w3c/alerts_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/w3c/commands_test.rb
+++ b/test/unit/android/webdriver/w3c/commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/android/webdriver/w3c/timeouts_test.rb
+++ b/test/unit/android/webdriver/w3c/timeouts_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/appium_lib_core_test.rb
+++ b/test/unit/appium_lib_core_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 class AppiumLibCoreTest

--- a/test/unit/common/element_test.rb
+++ b/test/unit/common/element_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/common/timer_test.rb
+++ b/test/unit/common/timer_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 class AppiumLibCoreTest

--- a/test/unit/common/websocket_test.rb
+++ b/test/unit/common/websocket_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/common_test.rb
+++ b/test/unit/common_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 class AppiumLibCoreTest

--- a/test/unit/image_element_test.rb
+++ b/test/unit/image_element_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 
 class AppiumLibCoreTest

--- a/test/unit/ios/device/mjsonwp/commands_test.rb
+++ b/test/unit/ios/device/mjsonwp/commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/ios/device/mjsonwp/definition_test.rb
+++ b/test/unit/ios/device/mjsonwp/definition_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/ios/device/w3c/commands_test.rb
+++ b/test/unit/ios/device/w3c/commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/ios/device/w3c/definition_test.rb
+++ b/test/unit/ios/device/w3c/definition_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/ios/webdriver/mjsonwp/actions_test.rb
+++ b/test/unit/ios/webdriver/mjsonwp/actions_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require 'webmock/minitest'
 

--- a/test/unit/script/commands_test.rb
+++ b/test/unit/script/commands_test.rb
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'test_helper'
 require './script/commands'
 


### PR DESCRIPTION
- Added `frozen_string_literal: true` for 2.3+
    - Keep 2.2 compatible methods
- Changed to use `+=` instead of `<<` for string literal
- Added license header

---

- functional tests worked fine
   - Android, iOS