### PR TITLE
add arguments for start activity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,9 +11,9 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
-  Max: 12
+  Max: 13
 Metrics/PerceivedComplexity:
-  Max: 12
+  Max: 13
 Metrics/ParameterLists:
   Max: 6
 Lint/NestedMethodDefinition:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Read `release_notes.md` for commit level details.
 ## [Unreleased]
 
 ### Enhancements
+- Add arguments for `start_activity`
+    - `intentAction`, `intentCategory`, `intentFlags`, `dontStopAppOnReset`
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -147,16 +147,20 @@ module Appium
         # @!method start_activity(opts)
         # Android only. Start a new activity within the current app or launch a new app and start the target activity.
         #
+        # Read https://developer.android.com/studio/command-line/adb#IntentSpec for each flags.
+        #
         # @param opts [Hash] Options
         # @option opts [String] :app_package The package owning the activity [required]
         # @option opts [String] :app_activity The target activity [required]
         # @option opts [String] :app_wait_package The package to start before the target package [optional]
         # @option opts [String] :app_wait_activity The activity to start before the target activity [optional]
-        # @option opts [String] :intent_action The intent action to give it when start the target activity [optional]
-        # @option opts [String] :intent_category The intent category to give it when start the target activity [optional]
-        # @option opts [String] :intent_flags The intent flag to give it when start the target activity [optional]
+        # @option opts [String] :intent_action The intent action to give it when start the target activity (`-a`) [optional]
+        # @option opts [String] :intent_category The intent category to give it when start the target activity (`-c`) [optional]
+        # @option opts [String] :intent_flags The intent flag to give it when start the target activity (`-f`) [optional]
         # @option opts [String] :optional_intent_arguments The optional intent action to give it when start the target activity [optional]
-        # @option opts [String] :dont_stop_app_on_reset Do not stop the app when the reset is called in Appium create/delete session [optional]
+        #                                                  You can set arbitrary arguments with space as string.
+        #                                                  e.g. `'--ez your_extra_bool bool --ei your_extra_int 1'`
+        # @option opts [bool] :dont_stop_app_on_reset Do not stop the app when the reset is called in Appium create/delete session [optional]
         #
         # @example
         #

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -152,6 +152,11 @@ module Appium
         # @option opts [String] :app_activity The target activity [required]
         # @option opts [String] :app_wait_package The package to start before the target package [optional]
         # @option opts [String] :app_wait_activity The activity to start before the target activity [optional]
+        # @option opts [String] :intent_action The intent action to give it when start the target activity [optional]
+        # @option opts [String] :intent_category The intent category to give it when start the target activity [optional]
+        # @option opts [String] :intent_flags The intent flag to give it when start the target activity [optional]
+        # @option opts [String] :optional_intent_arguments The optional intent action to give it when start the target activity [optional]
+        # @option opts [String] :dont_stop_app_on_reset Do not stop the app when the reset is called in Appium create/delete session [optional]
         #
         # @example
         #
@@ -333,8 +338,17 @@ module Appium
                 option[:appWaitPackage] = app_wait_package if app_wait_package
                 option[:appWaitActivity] = app_wait_activity if app_wait_activity
 
-                unknown_opts = opts.keys - %i(app_package app_activity app_wait_package app_wait_activity)
-                raise "Unknown options #{unknown_opts}" unless unknown_opts.empty?
+                intent_action = opts.fetch(:intent_action, nil)
+                intent_category = opts.fetch(:intent_category, nil)
+                intent_flags = opts.fetch(:intent_flags, nil)
+                optional_intent_arguments = opts.fetch(:optional_intent_arguments, nil)
+                dont_stop_app_on_reset = opts.fetch(:dont_stop_app_on_reset, nil)
+
+                option[:intentAction] = intent_action if intent_action
+                option[:intentCategory] = intent_category if intent_category
+                option[:intentFlags] = intent_flags if intent_flags
+                option[:optionalIntentArguments] = optional_intent_arguments if optional_intent_arguments
+                option[:dontStopAppOnReset] = dont_stop_app_on_reset if dont_stop_app_on_reset
 
                 execute :start_activity, {}, option
               end

--- a/test/unit/android/device/w3c/commands_test.rb
+++ b/test/unit/android/device/w3c/commands_test.rb
@@ -236,9 +236,9 @@ class AppiumLibCoreTest
 
           def test_start_activity
             stub_request(:post, "#{SESSION}/appium/device/start_activity")
-              .with(body: { appPackage: 'package', appActivity: 'activity' }.to_json)
+              .with(body: { appPackage: 'package', appActivity: 'activity', intentAction: 'action.MAIN' }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
-            @driver.start_activity(app_activity: 'activity', app_package: 'package')
+            @driver.start_activity(app_activity: 'activity', app_package: 'package', intent_action: 'action.MAIN')
 
             assert_requested(:post, "#{SESSION}/appium/device/start_activity", times: 1)
           end
@@ -246,11 +246,13 @@ class AppiumLibCoreTest
           def test_start_activity_with_wait
             stub_request(:post, "#{SESSION}/appium/device/start_activity")
               .with(body: { appPackage: 'package', appActivity: 'activity',
-                            appWaitPackage: 'wait_package', appWaitActivity: 'wait_activity' }.to_json)
+                            appWaitPackage: 'wait_package', appWaitActivity: 'wait_activity',
+                            intentAction: 'action.MAIN', dontStopAppOnReset: true }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
             @driver.start_activity(app_activity: 'activity', app_package: 'package',
-                                   app_wait_package: 'wait_package', app_wait_activity: 'wait_activity')
+                                   app_wait_package: 'wait_package', app_wait_activity: 'wait_activity',
+                                   intent_action: 'action.MAIN', dont_stop_app_on_reset: true)
 
             assert_requested(:post, "#{SESSION}/appium/device/start_activity", times: 1)
           end


### PR DESCRIPTION
```
  '/wd/hub/session/:sessionId/appium/device/start_activity': {
    POST: {
      command: 'startActivity',
      payloadParams: {
        required: ['appPackage', 'appActivity'],
        optional: ['appWaitPackage', 'appWaitActivity', 'intentAction',
          'intentCategory', 'intentFlags', 'optionalIntentArguments', 'dontStopAppOnReset']
      }
    }
  },
```

- https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md#uiautomator-1--2