### PR TITLE
ci: use macOS High Sierra for iOS since it fails on macOS host

### DIFF
--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -1,6 +1,10 @@
 # jobs for functional test
 parameters:
   vmImage: 'macOS-10.14'
+  vmImageForIOS: 'macOS-10.13' # Not sure the reason, but macOS 10.14 instance raises no info.plist error
+  xcodeForIOS: 10.1
+  xcodeForTVOS: 10.2
+  androidSDK: 28
   appiumVersion: 'beta'
   ignoreVersionSkip: true
   CI: true
@@ -9,7 +13,7 @@ jobs:
   # Run unit tests on different Node versions
   - job: func_test_ios_base
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      vmImage: ${{ parameters.vmImageForIOS }}
     variables:
       CI: ${{ parameters.ci }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
@@ -17,7 +21,7 @@ jobs:
     steps:
     - template: ./functional/ios_setup.yml
       parameters:
-        xcodeVersion: 10.1
+        xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
     - script: bundle exec rake test:func:ios TESTS=test/functional/ios/driver_test.rb,test/functional/ios/patch_test.rb
       displayName: Run tests
@@ -27,7 +31,7 @@ jobs:
 
   - job: func_test_ios_webdriver1
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      vmImage: ${{ parameters.vmImageForIOS }}
     variables:
       CI: ${{ parameters.ci }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
@@ -35,7 +39,7 @@ jobs:
     steps:
     - template: ./functional/ios_setup.yml
       parameters:
-        xcodeVersion: 10.1
+        xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
     - script: bundle exec rake test:func:ios TESTS=test/functional/ios/webdriver/create_session_test.rb,test/functional/ios/webdriver/w3c_actions_test.rb
       displayName: Run tests
@@ -45,7 +49,7 @@ jobs:
 
   - job: func_test_ios_webdriver2
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      vmImage: ${{ parameters.vmImageForIOS }}
     variables:
       CI: ${{ parameters.ci }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
@@ -53,7 +57,7 @@ jobs:
     steps:
     - template: ./functional/ios_setup.yml
       parameters:
-        xcodeVersion: 10.1
+        xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
     - script: bundle exec rake test:func:ios TESTS=test/functional/ios/webdriver/device_test.rb
       displayName: Run tests
@@ -63,7 +67,7 @@ jobs:
 
   - job: func_test_ios_ios1
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      vmImage: ${{ parameters.vmImageForIOS }}
     variables:
       CI: ${{ parameters.ci }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
@@ -71,7 +75,7 @@ jobs:
     steps:
     - template: ./functional/ios_setup.yml
       parameters:
-        xcodeVersion: 10.1
+        xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
     - script: bundle exec rake test:func:ios TESTS=test/functional/ios/ios/device_test.rb
       displayName: Run tests
@@ -81,7 +85,7 @@ jobs:
 
   - job: func_test_ios_ios2
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      vmImage: ${{ parameters.vmImageForIOS }}
     variables:
       CI: ${{ parameters.ci }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
@@ -89,7 +93,7 @@ jobs:
     steps:
     - template: ./functional/ios_setup.yml
       parameters:
-        xcodeVersion: 10.1
+        xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
     - script: npm install -g appium opencv4nodejs@4.17.0
       displayName: Install opencv4nodejs@4.17.0
@@ -101,7 +105,7 @@ jobs:
 
   - job: func_test_ios_ios3
     pool:
-      vmImage: ${{ parameters.vmImage }}
+      vmImage: ${{ parameters.vmImageForIOS }}
     variables:
       CI: ${{ parameters.ci }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
@@ -109,7 +113,7 @@ jobs:
     steps:
     - template: ./functional/ios_setup.yml
       parameters:
-        xcodeVersion: 10.1
+        xcodeVersion: ${{ parameters.xcodeForIOS }}
     - script: brew install ffmpeg && brew tap wix/brew && brew install wix/brew/applesimutils
       displayName: Install ffmpeg and applesimutils
     - template: ./functional/run_appium.yml
@@ -129,7 +133,7 @@ jobs:
     steps:
     - template: ./functional/ios_setup.yml
       parameters:
-        xcodeVersion: 10.2
+        xcodeVersion: ${{ parameters.xcodeForTVOS }}
     - template: ./functional/run_appium.yml
     - script: bundle exec rake test:func:ios TESTS=test/functional/ios/tv_driver_test.rb
       displayName: Run tests
@@ -142,7 +146,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: 28
+      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
@@ -159,7 +163,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: 28
+      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
@@ -176,7 +180,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: 28
+      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
@@ -193,7 +197,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: 28
+      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
@@ -210,7 +214,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: 28
+      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
@@ -227,7 +231,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: 28
+      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
@@ -244,7 +248,7 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     variables:
       CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: 28
+      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
       AUTOMATION_NAME_DROID: espresso
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}


### PR DESCRIPTION
Suddenly, below error started for all iOS tests on Azure.
Hosted macOS probably got issues, while hosted macOS high sierra worked as same as previous hosted macOS. (Will contact Azure support about it) 

```
 test_batch#AppiumLibCoreTest::DriverTest (55.14s)
Selenium::WebDriver::Error::UnknownError:         Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: simctl error running 'install': An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=22):
        Failed to install the requested application
        The application's Info.plist does not contain CFBundleShortVersionString.
        Ensure your bundle contains a CFBundleShortVersionString.
            UnknownError: An unknown server-side error occurred while processing the command. Original error: simctl error running 'install': An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=22):
            Failed to install the requested application
            The application's Info.plist does not contain CFBundleShortVersionString.
            Ensure your bundle contains a CFBundleShortVersionString.
                at getResponseForW3CError (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/protocol/errors.js:826:9)
                at asyncHandler (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:447:37)
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/response.rb:72:in `assert_ok'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/response.rb:34:in `initialize'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/http/common.rb:88:in `new'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/http/common.rb:88:in `create_response'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/http/default.rb:114:in `request'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/common/base/http_default.rb:81:in `call'
            /Users/vsts/agent/2.153.2/work/1/s/vendor/bundle/ruby/2.4.0/gems/selenium-webdriver-3.142.3/lib/selenium/webdriver/remote/bridge.rb:167:in `execute'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/common/base/bridge.rb:107:in `create_session'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/common/base/bridge.rb:47:in `handshake'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/common/base/driver.rb:34:in `initialize'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/driver.rb:348:in `new'
            /Users/vsts/agent/2.153.2/work/1/s/lib/appium_lib_core/driver.rb:348:in `start_driver'
            /Users/vsts/agent/2.153.2/work/1/s/test/functional/ios/driver_test.rb:23:in `setup'
```