### PR TITLE
can provide processArguments for activate app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Read `release_notes.md` for commit level details.
 ## [Unreleased]
 
 ### Enhancements
+- Add `environment` and `arguments` args for `#activate_app` method for iOS
+    - It can apply `processArguments` capability to the test app
+    - Make sure the test app is terminated before apply it 
 
 ### Bug fixes
 

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -201,10 +201,10 @@ jobs:
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
+      - template: ./functional/run_appium.yml
       - script: npm install -g opencv4nodejs@4.17.0
         displayName: Install opencv4nodejs@4.17.0
       - template: ./functional/android_setup.yml
-      - template: ./functional/run_appium.yml
       - script: bundle exec rake test:func:android TESTS=test/functional/android/android/image_comparison_test.rb,test/functional/android/android/mjpeg_server_test.rb
         displayName: Run tests
       - template: ./functional/publish_test_result.yml

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -201,10 +201,10 @@ jobs:
       IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
       APPIUM_VERSION: ${{ parameters.appiumVersion }}
     steps:
-      - template: ./functional/android_setup.yml
-      - template: ./functional/run_appium.yml
       - script: npm install -g opencv4nodejs@4.17.0
         displayName: Install opencv4nodejs@4.17.0
+      - template: ./functional/android_setup.yml
+      - template: ./functional/run_appium.yml
       - script: bundle exec rake test:func:android TESTS=test/functional/android/android/image_comparison_test.rb,test/functional/android/android/mjpeg_server_test.rb
         displayName: Run tests
       - template: ./functional/publish_test_result.yml

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -95,7 +95,7 @@ jobs:
       parameters:
         xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
-    - script: npm install -g appium opencv4nodejs@4.17.0
+    - script: npm install -g opencv4nodejs@4.17.0
       displayName: Install opencv4nodejs@4.17.0
     - script: bundle exec rake test:func:ios TESTS=test/functional/ios/ios/device_wda_attachment_test.rb,test/functional/ios/ios/image_comparison_test.rb
       displayName: Run tests
@@ -203,7 +203,7 @@ jobs:
     steps:
       - template: ./functional/android_setup.yml
       - template: ./functional/run_appium.yml
-      - script: npm install -g appium opencv4nodejs@4.17.0
+      - script: npm install -g opencv4nodejs@4.17.0
         displayName: Install opencv4nodejs@4.17.0
       - script: bundle exec rake test:func:android TESTS=test/functional/android/android/image_comparison_test.rb,test/functional/android/android/mjpeg_server_test.rb
         displayName: Run tests

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -657,14 +657,19 @@ module Appium
         end
 
         # Activate(Launch) the specified app.
+        # @param [Strong] app_id BundleId for iOS or package name for Android
+        # @param [Array] arguments Only for XCUITest. Provides 'launchArguments' to the app
+        # @param [Hash] environment Only for XCUITest. Provides 'launchEnvironment' to the app
         # @return [Hash]
         #
         # @example
         #
         #   @driver.activate_app("io.appium.bundle") #=> {}
+        #   @driver.activate_app("io.appium.bundle", arguments: ['arg1', 'arg2'],
+        #                                            environment: { 'IOS_TESTING': 'happy testing' }) #=> {}
         #
-        def activate_app(app_id)
-          @bridge.activate_app(app_id)
+        def activate_app(app_id, arguments: nil, environment: nil)
+          @bridge.activate_app(app_id, arguments: arguments, environment: environment)
         end
 
         # Terminate the specified app.

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -657,9 +657,15 @@ module Appium
         end
 
         # Activate(Launch) the specified app.
+        #
+        # You can provide +launchArguments+ and +launchEnvironment+ for XCUITest.
+        # Please ensure the target app is not running before applying them since
+        # they cannot work if the target app was running.
+        #
+        #
         # @param [Strong] app_id BundleId for iOS or package name for Android
-        # @param [Array] arguments Only for XCUITest. Provides 'launchArguments' to the app
-        # @param [Hash] environment Only for XCUITest. Provides 'launchEnvironment' to the app
+        # @param [Array] arguments Only for XCUITest. Provides +launchArguments+ to the app
+        # @param [Hash] environment Only for XCUITest. Provides +launchEnvironment+ to the app
         # @return [Hash]
         #
         # @example

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -675,7 +675,7 @@ module Appium
         #                                            environment: { 'IOS_TESTING': 'happy testing' }) #=> {}
         #
         def activate_app(app_id, arguments: nil, environment: nil)
-          @bridge.activate_app(app_id, arguments: arguments, environment: environment)
+          @bridge.activate_app(app_id, { arguments: arguments, environment: environment })
         end
 
         # Terminate the specified app.

--- a/lib/appium_lib_core/common/device/app_management.rb
+++ b/lib/appium_lib_core/common/device/app_management.rb
@@ -74,7 +74,8 @@ module Appium
             execute :app_installed?, {}, bundleId: app_id
           end
 
-          def activate_app(app_id)
+          def activate_app(app_id, _opts)
+            # _opts is used by XCTest so far
             # required: [['appId'], ['bundleId']]
             execute :activate_app, {}, { bundleId: app_id }
           end

--- a/lib/appium_lib_core/common/device/app_management.rb
+++ b/lib/appium_lib_core/common/device/app_management.rb
@@ -74,9 +74,15 @@ module Appium
             execute :app_installed?, {}, bundleId: app_id
           end
 
-          def activate_app(app_id)
+          def activate_app(app_id, arguments: nil, environment: nil)
+            args = { bundleId: app_id }
+
+            # arguments and environment are for xcuitest
+            args[:arguments] = arguments unless arguments.nil?
+            args[:environment] = environment unless environment.nil?
+
             # required: [['appId'], ['bundleId']]
-            execute :activate_app, {}, bundleId: app_id
+            execute :activate_app, {}, args
           end
 
           def terminate_app(app_id, timeout: nil)

--- a/lib/appium_lib_core/common/device/app_management.rb
+++ b/lib/appium_lib_core/common/device/app_management.rb
@@ -62,7 +62,7 @@ module Appium
             # required: [['appId'], ['bundleId']]
             args = { appId: id }
 
-            args[:options] = {} unless keep_data.nil? || timeout.nil?
+            args[:options] = {} unless keep_data.nil? && timeout.nil?
             args[:options][:keepData] = keep_data unless keep_data.nil?
             args[:options][:timeout] = timeout unless timeout.nil?
 
@@ -78,8 +78,9 @@ module Appium
             args = { bundleId: app_id }
 
             # arguments and environment are for xcuitest
-            args[:arguments] = arguments unless arguments.nil?
-            args[:environment] = environment unless environment.nil?
+            args[:options] = {} unless arguments.nil? && environment.nil?
+            args[:options][:arguments] = arguments unless arguments.nil?
+            args[:options][:environment] = environment unless environment.nil?
 
             # required: [['appId'], ['bundleId']]
             execute :activate_app, {}, args

--- a/lib/appium_lib_core/common/device/app_management.rb
+++ b/lib/appium_lib_core/common/device/app_management.rb
@@ -74,16 +74,9 @@ module Appium
             execute :app_installed?, {}, bundleId: app_id
           end
 
-          def activate_app(app_id, arguments: nil, environment: nil)
-            args = { bundleId: app_id }
-
-            # arguments and environment are for xcuitest
-            args[:options] = {} unless arguments.nil? && environment.nil?
-            args[:options][:arguments] = arguments unless arguments.nil?
-            args[:options][:environment] = environment unless environment.nil?
-
+          def activate_app(app_id)
             # required: [['appId'], ['bundleId']]
-            execute :activate_app, {}, args
+            execute :activate_app, {}, { bundleId: app_id }
           end
 
           def terminate_app(app_id, timeout: nil)

--- a/lib/appium_lib_core/ios/xcuitest/device.rb
+++ b/lib/appium_lib_core/ios/xcuitest/device.rb
@@ -196,8 +196,11 @@ module Appium
 
               # Xcuitest, Override included method in bridge
               ::Appium::Core::Device.add_endpoint_method(:activate_app) do
-                def activate_app(app_id, arguments: nil, environment: nil)
+                def activate_app(app_id, opts)
                   args = { bundleId: app_id }
+
+                  arguments = opts.delete(:arguments)
+                  environment = opts.delete(:environment)
 
                   args[:options] = {} unless arguments.nil? && environment.nil?
                   args[:options][:arguments] = arguments unless arguments.nil?

--- a/lib/appium_lib_core/ios/xcuitest/device.rb
+++ b/lib/appium_lib_core/ios/xcuitest/device.rb
@@ -194,6 +194,20 @@ module Appium
                 end
               end
 
+              # Xcuitest, Override included method in bridge
+              ::Appium::Core::Device.add_endpoint_method(:activate_app) do
+                def activate_app(app_id, arguments: nil, environment: nil)
+                  args = { bundleId: app_id }
+
+                  args[:options] = {} unless arguments.nil? && environment.nil?
+                  args[:options][:arguments] = arguments unless arguments.nil?
+                  args[:options][:environment] = environment unless environment.nil?
+
+                  # required: [['appId'], ['bundleId']]
+                  execute :activate_app, {}, args
+                end
+              end
+
               Performance.add_methods
               Screen.add_methods
               Battery.add_methods

--- a/test/functional/ios/ios/device_test.rb
+++ b/test/functional/ios/ios/device_test.rb
@@ -135,10 +135,10 @@ class AppiumLibCoreTest
                                      arguments: %w(arg1 arg2),
                                      environment: { 'IOS_TESTING': 'happy testing' }) == {}
         # add check the arguments
-        # info = @driver.execute_script('mobile: deviceInfo', {})
-        # assert info['processArgument']['args'] == ['arg1', 'arg2']
-        # assert info['processArgument']['env'] == { 'IOS_TESTING': 'happy testing' }
-        # assert info['processArgument']['bundleId'] == 'com.example.apple-samplecode.UICatalog'
+        # pa = @driver.execute_script('mobile: deviceInfo', {})['currentActiveApplication']['processArguments']
+        # assert pa['args'] == ['arg1', 'arg2']
+        # assert pa['env'] == { 'IOS_TESTING': 'happy testing' }
+        # assert pa['bundleId'] == 'com.example.apple-samplecode.UICatalog'
         assert @@driver.app_state('com.example.apple-samplecode.UICatalog') == :running_in_foreground
       end
 

--- a/test/functional/ios/ios/device_test.rb
+++ b/test/functional/ios/ios/device_test.rb
@@ -131,7 +131,14 @@ class AppiumLibCoreTest
         assert @@driver.terminate_app('com.example.apple-samplecode.UICatalog')
         assert @@driver.app_state('com.example.apple-samplecode.UICatalog') == :not_running
 
-        assert @@driver.activate_app('com.example.apple-samplecode.UICatalog') == {}
+        assert @@driver.activate_app('com.example.apple-samplecode.UICatalog',
+                                     arguments: %w(arg1 arg2),
+                                     environment: { 'IOS_TESTING': 'happy testing' }) == {}
+        # add check the arguments
+        # info = @driver.execute_script('mobile: deviceInfo', {})
+        # assert info['processArgument']['args'] == ['arg1', 'arg2']
+        # assert info['processArgument']['env'] == { 'IOS_TESTING': 'happy testing' }
+        # assert info['processArgument']['bundleId'] == 'com.example.apple-samplecode.UICatalog'
         assert @@driver.app_state('com.example.apple-samplecode.UICatalog') == :running_in_foreground
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,6 +116,7 @@ class AppiumLibCoreTest
           # But sometimes `false` is necessary. It leads regressions sometimes though.
           waitForQuiescence: true,
           reduceMotion: true,
+          processArguments: { args: %w(happy tseting), env: { HAPPY: 'testing' } },
           screenshotQuality: 2 # The lowest quality screenshots
         },
         appium_lib: {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -224,13 +224,13 @@ class AppiumLibCoreTest
           systemPort: system_port,
           language: 'en',
           locale: 'US',
-          adbExecTimeout: 10_000, # 10 sec
           # An emulator 8.1 has Chrome/61.0.3163.98
           # Download a chrome driver from https://chromedriver.storage.googleapis.com/index.html?path=2.34/
           # chromedriverExecutable: "#{Dir.pwd}/test/functional/app/chromedriver_2.34",
           chromeOptions: {
             args: ['--disable-popup-blocking']
           },
+          adbExecTimeout: 60_000, # ms
           uiautomator2ServerLaunchTimeout: 60_000 # ms
         },
         appium_lib: {

--- a/test/unit/android/device/w3c/app_management_test.rb
+++ b/test/unit/android/device/w3c/app_management_test.rb
@@ -171,6 +171,16 @@ class AppiumLibCoreTest
             assert_requested(:post, "#{SESSION}/appium/device/remove_app", times: 1)
           end
 
+          def test_remove_app_with_only_keepdata
+            stub_request(:post, "#{SESSION}/appium/device/remove_app")
+              .with(body: { appId: 'com.app.id', options: { keepData: false } }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+
+            @driver.remove_app 'com.app.id', keep_data: false
+
+            assert_requested(:post, "#{SESSION}/appium/device/remove_app", times: 1)
+          end
+
           def test_app_installed?
             stub_request(:post, "#{SESSION}/appium/device/app_installed")
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)

--- a/test/unit/ios/device/w3c/app_management_test.rb
+++ b/test/unit/ios/device/w3c/app_management_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'test_helper'
+require 'webmock/minitest'
+
+# $ rake test:unit TEST=test/unit/ios/device/w3c/app_management_test.rb
+class AppiumLibCoreTest
+  module IOS
+    module Device
+      module W3C
+        class AppManagementTest < Minitest::Test
+          include AppiumLibCoreTest::Mock
+
+          def setup
+            @core ||= ::Appium::Core.for(Caps.ios)
+            @driver ||= ios_mock_create_session_w3c
+          end
+
+          def test_activate_app
+            stub_request(:post, "#{SESSION}/appium/device/activate_app")
+              .with(body: { bundleId: 'com.app.id' }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+
+            @driver.activate_app 'com.app.id'
+            assert_requested(:post, "#{SESSION}/appium/device/activate_app", times: 1)
+          end
+
+          def test_activate_app_with_env
+            stub_request(:post, "#{SESSION}/appium/device/activate_app")
+              .with(body: { bundleId: 'com.app.id', options: { environment: { IOS_TESTING: 'happy testing' } } }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+
+            @driver.activate_app 'com.app.id', environment: { IOS_TESTING: 'happy testing' }
+            assert_requested(:post, "#{SESSION}/appium/device/activate_app", times: 1)
+          end
+
+          def test_activate_app_with_both
+            stub_request(:post, "#{SESSION}/appium/device/activate_app")
+              .with(body: { bundleId: 'com.app.id', options: { arguments: %w(1 2 3),
+                                                               environment: { IOS_TESTING: 'happy testing' } } }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
+
+            @driver.activate_app 'com.app.id', arguments: %w(1 2 3), environment: { IOS_TESTING: 'happy testing' }
+
+            assert_requested(:post, "#{SESSION}/appium/device/activate_app", times: 1)
+          end
+        end # class AppManagementTest
+      end # module W3C
+    end # module Device
+  end # module IOS
+end # class AppiumLibCoreTest

--- a/test/unit/ios/device/w3c/app_management_test.rb
+++ b/test/unit/ios/device/w3c/app_management_test.rb
@@ -38,7 +38,9 @@ class AppiumLibCoreTest
           end
 
           def test_activate_app_with_env
-            stub_request(:post, "#{SESSION}/appium/device/activate_app")
+            skip unless @core.automation_name == :xcuitest
+
+              stub_request(:post, "#{SESSION}/appium/device/activate_app")
               .with(body: { bundleId: 'com.app.id', options: { environment: { IOS_TESTING: 'happy testing' } } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
@@ -47,6 +49,8 @@ class AppiumLibCoreTest
           end
 
           def test_activate_app_with_both
+            skip unless @core.automation_name == :xcuitest
+
             stub_request(:post, "#{SESSION}/appium/device/activate_app")
               .with(body: { bundleId: 'com.app.id', options: { arguments: %w(1 2 3),
                                                                environment: { IOS_TESTING: 'happy testing' } } }.to_json)

--- a/test/unit/ios/device/w3c/app_management_test.rb
+++ b/test/unit/ios/device/w3c/app_management_test.rb
@@ -40,7 +40,7 @@ class AppiumLibCoreTest
           def test_activate_app_with_env
             skip unless @core.automation_name == :xcuitest
 
-              stub_request(:post, "#{SESSION}/appium/device/activate_app")
+            stub_request(:post, "#{SESSION}/appium/device/activate_app")
               .with(body: { bundleId: 'com.app.id', options: { environment: { IOS_TESTING: 'happy testing' } } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 


### PR DESCRIPTION
as same as:
```
driver.execute_script('mobile: launchApp', {
    'bundleId': 'io.appium.bundle',
    'arguments': ['arg1', 'arg2'],
    'environment': { 'IOS_TESTING': 'happy testing' }
})
```