### PR TITLE
ci: disable opencv to avoid installation error on ci

### DIFF
--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -95,9 +95,7 @@ jobs:
       parameters:
         xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
-    - script: npm install -g opencv4nodejs@5.1.0
-      displayName: Install opencv4nodejs@5.1.0
-    - script: bundle exec rake test:func:ios TESTS=test/functional/ios/ios/device_wda_attachment_test.rb,test/functional/ios/ios/image_comparison_test.rb
+    - script: bundle exec rake test:func:ios TESTS=test/functional/ios/ios/device_wda_attachment_test.rb,test/functional/ios/ios/search_context_test.rb
       displayName: Run tests
     - template: ./functional/publish_test_result.yml
       parameters:
@@ -117,7 +115,7 @@ jobs:
     - script: brew install ffmpeg && brew tap wix/brew && brew install wix/brew/applesimutils
       displayName: Install ffmpeg and applesimutils
     - template: ./functional/run_appium.yml
-    - script: bundle exec rake test:func:ios TESTS=test/functional/ios/ios/mjpeg_server_test.rb,test/functional/ios/ios/mobile_commands_test.rb,test/functional/ios/ios/search_context_test.rb
+    - script: bundle exec rake test:func:ios TESTS=test/functional/ios/ios/mjpeg_server_test.rb,test/functional/ios/ios/mobile_commands_test.rb
       displayName: Run tests
     - template: ./functional/publish_test_result.yml
       parameters:
@@ -140,6 +138,28 @@ jobs:
     - template: ./functional/publish_test_result.yml
       parameters:
         xcodeVersion: 'Run_func_test_on_iOS_tv'
+
+# Skip since opencv4nodejs fails to install on the macOS instance
+#  - job: func_test_ios_opencv
+#    pool:
+#      vmImage: ${{ parameters.vmImageForIOS }}
+#    variables:
+#      CI: ${{ parameters.ci }}
+#      IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
+#      APPIUM_VERSION: ${{ parameters.appiumVersion }}
+#    steps:
+#      - template: ./functional/ios_setup.yml
+#        parameters:
+#          xcodeVersion: ${{ parameters.xcodeForIOS }}
+#      - template: ./functional/run_appium.yml
+#      - script: npm install -g opencv4nodejs@5.1.0
+#        displayName: Install opencv4nodejs@5.1.0
+#      - script: bundle exec rake test:func:ios test/functional/ios/ios/image_comparison_test.rb
+#        displayName: Run tests
+#      - template: ./functional/publish_test_result.yml
+#        parameters:
+#          xcodeVersion: 'Run_func_test_on_iOS_opencv'
+
 
   - job: func_test_android_base
     pool:
@@ -227,38 +247,13 @@ jobs:
     steps:
       - template: ./functional/android_setup.yml
       - template: ./functional/run_appium.yml
-      - script: npm install -g opencv4nodejs@5.1.0
-        displayName: Install opencv4nodejs@5.1.0
-      - script: bundle exec rake test:func:android TESTS=test/functional/android/android/image_comparison_test.rb,test/functional/android/android/mjpeg_server_test.rb
-        displayName: Run tests
-      - template: ./functional/publish_test_result.yml
-        parameters:
-          xcodeVersion: 'func_test_android_android2'
-
-  - job: func_test_android_android3
-    pool:
-      vmImage: ${{ parameters.vmImage }}
-    variables:
-      CI: ${{ parameters.ci }}
-      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
-      IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
-      APPIUM_VERSION: ${{ parameters.appiumVersion }}
-    strategy:
-      matrix:
-        uiautomator2:
-          AUTOMATION_NAME_DROID: 'uiautomator2'
-        espresso:
-          AUTOMATION_NAME_DROID: 'espresso'
-    steps:
-      - template: ./functional/android_setup.yml
-      - template: ./functional/run_appium.yml
-      - script: bundle exec rake test:func:android TESTS=test/functional/android/android/mobile_commands_test.rb,test/functional/android/android/search_context_test.rb
+      - script: bundle exec rake test:func:android TESTS=test/functional/android/android/mobile_commands_test.rb,test/functional/android/android/search_context_test.rb,test/functional/android/android/mjpeg_server_test.rb
         displayName: Run tests
       - template: ./functional/publish_test_result.yml
         parameters:
           xcodeVersion: 'func_test_android_android3'
 
-  - job: func_test_android_android4
+  - job: func_test_android_android3
     pool:
       vmImage: ${{ parameters.vmImage }}
     variables:
@@ -279,7 +274,7 @@ jobs:
         displayName: Run tests
       - template: ./functional/publish_test_result.yml
         parameters:
-          xcodeVersion: 'func_test_android_android4'
+          xcodeVersion: 'func_test_android_android3'
 
   - job: func_test_android_mobile_command_espresso
     pool:
@@ -304,3 +299,29 @@ jobs:
       - template: ./functional/publish_test_result.yml
         parameters:
           xcodeVersion: 'func_test_android_mobile_command_espresso'
+
+# Skip since opencv4nodejs fails to install on the macOS instance
+#  - job: func_test_android_opencv
+#    pool:
+#      vmImage: ${{ parameters.vmImage }}
+#    variables:
+#      CI: ${{ parameters.ci }}
+#      ANDROID_SDK_VERSION: ${{ parameters.androidSDK }}
+#      IGNORE_VERSION_SKIP: ${{ parameters.ignoreVersionSkip }}
+#      APPIUM_VERSION: ${{ parameters.appiumVersion }}
+#    strategy:
+#      matrix:
+#        uiautomator2:
+#          AUTOMATION_NAME_DROID: 'uiautomator2'
+#        espresso:
+#          AUTOMATION_NAME_DROID: 'espresso'
+#    steps:
+#      - template: ./functional/android_setup.yml
+#      - template: ./functional/run_appium.yml
+#      - script: npm install -g opencv4nodejs@5.1.0
+#        displayName: Install opencv4nodejs@5.1.0
+#      - script: bundle exec rake test:func:android TESTS=test/functional/android/android/image_comparison_test.rb
+#        displayName: Run tests
+#      - template: ./functional/publish_test_result.yml
+#        parameters:
+#          xcodeVersion: 'func_test_android_android2'

--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -95,8 +95,8 @@ jobs:
       parameters:
         xcodeVersion: ${{ parameters.xcodeForIOS }}
     - template: ./functional/run_appium.yml
-    - script: npm install -g opencv4nodejs@4.17.0
-      displayName: Install opencv4nodejs@4.17.0
+    - script: npm install -g opencv4nodejs@5.1.0
+      displayName: Install opencv4nodejs@5.1.0
     - script: bundle exec rake test:func:ios TESTS=test/functional/ios/ios/device_wda_attachment_test.rb,test/functional/ios/ios/image_comparison_test.rb
       displayName: Run tests
     - template: ./functional/publish_test_result.yml
@@ -227,8 +227,8 @@ jobs:
     steps:
       - template: ./functional/android_setup.yml
       - template: ./functional/run_appium.yml
-      - script: npm install -g opencv4nodejs@4.17.0
-        displayName: Install opencv4nodejs@4.17.0
+      - script: npm install -g opencv4nodejs@5.1.0
+        displayName: Install opencv4nodejs@5.1.0
       - script: bundle exec rake test:func:android TESTS=test/functional/android/android/image_comparison_test.rb,test/functional/android/android/mjpeg_server_test.rb
         displayName: Run tests
       - template: ./functional/publish_test_result.yml


### PR DESCRIPTION
Suddenly, below started

```
(node:2911) UnhandledPromiseRejectionWarning: Error: Cannot find module '/Users/vsts/agent/2.155.1/work/1/s/package.json'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at /usr/local/lib/node_modules/opencv4nodejs/node_modules/opencv-build/build/install.js:75:43
    at step (/usr/local/lib/node_modules/opencv4nodejs/node_modules/opencv-build/build/install.js:32:23)
    at Object.next (/usr/local/lib/node_modules/opencv4nodejs/node_modules/opencv-build/build/install.js:13:53)
    at /usr/local/lib/node_modules/opencv4nodejs/node_modules/opencv-build/build/install.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/usr/local/lib/node_modules/opencv4nodejs/node_modules/opencv-build/build/install.js:3:12)
(node:2911) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2911) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

> opencv4nodejs@4.17.0 install /usr/local/lib/node_modules/opencv4nodejs
> node-gyp rebuild

  CXX(target) Release/obj.target/opencv4nodejs/cc/opencv4nodejs.o
In file included from ../cc/opencv4nodejs.cc:2:
In file included from ../cc/ExternalMemTracking.h:2:
In file included from ../cc/CustomMatAllocator.h:8:
../cc/core/Size.h:1:10: fatal error: 'opencv2/core.hpp' file not found
#include <opencv2/core.hpp>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [Release/obj.target/opencv4nodejs/cc/opencv4nodejs.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/vsts/hostedtoolcache/node/10.16.3/x64/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:198:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12)
gyp ERR! System Darwin 18.7.0
gyp ERR! command "/Users/vsts/hostedtoolcache/node/10.16.3/x64/bin/node" "/Users/vsts/hostedtoolcache/node/10.16.3/x64/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /usr/local/lib/node_modules/opencv4nodejs
gyp ERR! node -v v10.16.3
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok 
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! opencv4nodejs@4.17.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the opencv4nodejs@4.17.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```