### PR TITLE
ci: remove Chromedriver option for install

### DIFF
--- a/ci-jobs/functional/run_appium.yml
+++ b/ci-jobs/functional/run_appium.yml
@@ -3,7 +3,7 @@ steps:
   inputs:
     versionSpec: 10.x
   displayName: Install Node 10.x
-- script: npm install -g appium@${APPIUM_VERSION} --chromedriver_version='2.44'
+- script: npm install -g appium@${APPIUM_VERSION}
   displayName: Install appium beta
 - script: npm install -g mjpeg-consumer
   displayName: Install MJPEG Consumer


### PR DESCRIPTION
Below returned 503 error.. and maybe i can remove this for ruby test suite

```
[13:51:44] [Chromedriver Install] Downloading https://chromedriver.storage.googleapis.com/2.44/chromedriver_mac64.zip...
```