### PR TITLE
fix: x-idempotency-key only for a new session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Read `release_notes.md` for commit level details.
     - `file_field_name`, `form_fields` and `headers` are available since Appium 1.18.0
 
 ### Bug fixes
+- Fix `x-idempotency-key` header to add it only in new session request (https://github.com/appium/ruby_lib_core/issues/262)
 
 ### Deprecations
 

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -105,7 +105,8 @@ module Appium
       # @return [Appium::Core::Base::Http::Default] the http client
       attr_reader :http_client
 
-      # Return if adding 'x-idempotency-key' header is each request.
+      # Return if adding 'x-idempotency-key' header is enabled for each new session request.
+      # Following commands should not have the key.
       # The key is unique for each http client instance. Defaults to <code>true</code>
       # https://github.com/appium/appium-base-driver/pull/400
       # @return [Bool]
@@ -370,6 +371,9 @@ module Appium
         rescue Errno::ECONNREFUSED
           raise "ERROR: Unable to connect to Appium. Is the server running on #{@custom_url}?"
         end
+
+        # We only need the key for a new session request. Should remove it for other following commands.
+        @http_client.additional_headers.delete Appium::Core::Base::Http::RequestHeaders::KEYS[:idempotency]
 
         # If "automationName" is set only server side, this method set "automationName" attribute into @automation_name.
         # Since @automation_name is set only client side before start_driver is called.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -415,6 +415,7 @@ class AppiumLibCoreTest
       }.to_json
 
       stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
+        .with(headers: { 'X-Idempotency-Key' => /.+/ })
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts/implicit_wait")
@@ -423,6 +424,7 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
+      assert_equal({}, driver.send(:bridge).http.additional_headers)
       assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
       assert_requested(:post, "#{SESSION}/timeouts/implicit_wait", times: 1)
       driver
@@ -448,6 +450,7 @@ class AppiumLibCoreTest
       }.to_json
 
       stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
+        .with(headers: { 'X-Idempotency-Key' => /.+/ })
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts")
@@ -456,6 +459,7 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
+      assert_equal({}, driver.send(:bridge).http.additional_headers)
       assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
       assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 5_000 }.to_json, times: 1)
       driver


### PR DESCRIPTION
fix https://github.com/appium/ruby_lib_core/issues/262