### PR TITLE
feat: Remove timeout deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Read `release_notes.md` for commit level details.
 ## [Unreleased]
 
 ### Enhancements
+- Remove deprecated `Selenium::WebDriver::Error::TimeOutError` in `webdriver-selenium` gem
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/common/base/search_context.rb
+++ b/lib/appium_lib_core/common/base/search_context.rb
@@ -135,8 +135,6 @@ module Appium
           by = _set_by_from_finders(how)
           begin
             bridge.find_element_by by, what.to_s, ref
-          rescue Selenium::WebDriver::Error::TimeOutError # will deprecate
-            raise Selenium::WebDriver::Error::NoSuchElementError
           rescue Selenium::WebDriver::Error::TimeoutError
             raise Selenium::WebDriver::Error::NoSuchElementError
           end
@@ -152,8 +150,6 @@ module Appium
           by = _set_by_from_finders(how)
           begin
             bridge.find_elements_by by, what.to_s, ref
-          rescue Selenium::WebDriver::Error::TimeOutError # will deprecate
-            []
           rescue Selenium::WebDriver::Error::TimeoutError
             []
           end


### PR DESCRIPTION
https://github.com/SeleniumHQ/selenium/blob/da134d42e586efb5678dd40f8a648ab13ef6a3f3/rb/CHANGES#L323
I tested with specifying selenium-webdriver `3.14.1` on my local to ensure this did not need to update dependencies.
https://github.com/appium/ruby_lib/issues/869


I also override error as `time out` or `timeout`. Both can overt to proper timeout error with this change. It should be safe to merge if all tests are green.