### PR TITLE
ci: bump ci android version

### DIFF
--- a/ci-jobs/functional_test.yml
+++ b/ci-jobs/functional_test.yml
@@ -4,7 +4,7 @@ parameters:
   vmImageForIOS: 'macOS-10.15' # Not sure the reason, but macOS 10.14 instance raises no info.plist error
   xcodeForIOS: 11.5
   xcodeForTVOS: 11.5
-  androidSDK: 29
+  androidSDK: 30
   appiumVersion: 'beta'
   ignoreVersionSkip: true
   CI: true


### PR DESCRIPTION
Hm, on 30 emulator, `shell input text /normal/` is text type. Only this action failed.

```
@driver.execute_script 'mobile: performEditorAction', { action: 'normal' }
```

![image](https://user-images.githubusercontent.com/5511591/84404630-0e8a8700-ac42-11ea-9bb4-d0aaf50c36a9.png)


```
[HTTP] --> POST /wd/hub/session/56b4835f-8ea1-4623-ab83-d79c82a6a1ce/execute/sync
[HTTP] {"script":"mobile: performEditorAction","args":[{"action":"normal"}]}
[debug] [W3C (56b4835f)] Calling AppiumDriver.execute() with args: ["mobile: performEditorAction",[{"action":"normal"}],"56b4835f-8ea1-4623-ab83-d79c82a6a1ce"]
[AndroidDriver] Executing native command 'mobile: performEditorAction'
[debug] [ADB] Performing editor action: normal
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell settings get secure default_input_method'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell ime set io.appium.settings/.AppiumIME'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell input text /normal/'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell ime set io.appium.settings/.UnicodeIME'
[debug] [W3C (56b4835f)] Responding to client with driver.execute() result: null
[HTTP] <-- POST /wd/hub/session/56b4835f-8ea1-4623-ab83-d79c82a6a1ce/execute/sync 200 1638 ms - 14
[HTTP]
```

Expected:
![image](https://user-images.githubusercontent.com/5511591/84404799-44c80680-ac42-11ea-906a-46e2dc1a8092.png)
