### PR TITLE
test: use predicate instead of name for 'value'

### DIFF
--- a/test/functional/ios/ios/device_test.rb
+++ b/test/functional/ios/ios/device_test.rb
@@ -255,7 +255,7 @@ class AppiumLibCoreTest
         e = @@core.wait { @@driver.find_element :accessibility_id, TEXT_FIELD }
         e.click
 
-        text = @@core.wait { @@driver.find_element :name, 'Placeholder text' }
+        text = @@core.wait { @@driver.find_element :predicate, 'value == "Placeholder text"' }
         text.click
 
         assert @@driver.find_element(:class, 'XCUIElementTypeKeyboard').displayed?

--- a/test/functional/ios/patch_test.rb
+++ b/test/functional/ios/patch_test.rb
@@ -44,7 +44,7 @@ class AppiumLibCoreTest
       text = @@core.wait { @@driver.find_element :class, 'XCUIElementTypeTextField' }
       text.type 'hello'
 
-      e = @@core.wait { @@driver.find_element :name, 'hello' }
+      e = @@core.wait { @@driver.find_element :predicate, 'value == "hello"' }
       assert_equal 'hello', e.value
 
       @@driver.back
@@ -71,7 +71,7 @@ class AppiumLibCoreTest
       text = @@core.wait { @@driver.find_element :class, 'XCUIElementTypeTextField' }
       text.immediate_value 'hello'
 
-      text = @@core.wait { @@driver.find_element :name, 'hello' }
+      text = @@core.wait { @@driver.find_element :predicate, 'value == "hello"' }
       assert_equal 'hello', text.value
 
       @@driver.back

--- a/test/functional/ios/webdriver/device_test.rb
+++ b/test/functional/ios/webdriver/device_test.rb
@@ -58,7 +58,7 @@ class AppiumLibCoreTest
 
         @@core.wait { @@driver.find_element :accessibility_id, 'Text Fields' }.click
 
-        e = @@core.wait { @@driver.find_element :name, 'Placeholder text' }
+        e = @@core.wait { @@driver.find_element :predicate, 'value == "Placeholder text"' }
         e.click
         @@driver.set_immediate_value e, 'hello'
 

--- a/test/functional/ios/webdriver/w3c_actions_test.rb
+++ b/test/functional/ios/webdriver/w3c_actions_test.rb
@@ -48,16 +48,16 @@ class AppiumLibCoreTest
         el = @@core.wait { @@driver.find_element(:accessibility_id, 'Segmented Controls') }
         @@driver.action.click(el).perform
 
-        [1, 2, 3].each do |_value|
+        [1, 2, 3].each do |count|
           el = @@driver.find_element(:accessibility_id, 'TINTED')
           rect = el.rect
 
           @@driver.execute_script('mobile: scroll', direction: 'down')
 
-          break if el.rect.y < rect.y
+          break if el.rect.y <= rect.y
 
           # fail
-          assert false if value == 3
+          assert false if count == 3
         end
         assert true
       end
@@ -74,7 +74,7 @@ class AppiumLibCoreTest
 
         w3c_scroll @@driver
 
-        assert el.rect.y < rect.y
+        assert el.rect.y <= rect.y
       end
 
       def test_click_w3c_landscape


### PR DESCRIPTION
since Appium 1.19.1

https://github.com/appium/WebDriverAgent/pull/416#issuecomment-718214299

Uses `value` (could be `wdValue` as well) since the key name is printed in source tree

---

This should work on the previous versions, too.