### PR TITLE
feat: add safari and geckodriver

### DIFF
--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -510,14 +510,21 @@ module Appium
           end
         when :ios, :tvos
           case automation_name
+          when :safari
+            ::Appium::Logger.debug('iOS SafariDriver')
           when :xcuitest
             ::Appium::Core::Ios::Xcuitest::Bridge.for self
           else # default and UIAutomation
             ::Appium::Core::Ios::Uiautomation::Bridge.for self
           end
         when :mac
-          # no Mac specific extentions
-          ::Appium::Logger.debug('mac')
+          case automation_name
+          when :safari
+            ::Appium::Logger.debug('macOS SafariDriver')
+          else
+            # no Mac specific extentions
+            ::Appium::Logger.debug('macOS Native')
+          end
         when :windows
           ::Appium::Core::Windows::Bridge.for self
         when :tizen

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -505,6 +505,8 @@ module Appium
             ::Appium::Core::Android::Espresso::Bridge.for self
           when :uiautomator2
             ::Appium::Core::Android::Uiautomator2::Bridge.for self
+          when :gecko
+            ::Appium::Logger.debug('Gecko Driver for Android')
           else # default and UiAutomator
             ::Appium::Core::Android::Uiautomator1::Bridge.for self
           end
@@ -521,12 +523,19 @@ module Appium
           case automation_name
           when :safari
             ::Appium::Logger.debug('macOS SafariDriver')
+          when :gecko
+            ::Appium::Logger.debug('Gecko Driver for macOS')
           else
             # no Mac specific extentions
             ::Appium::Logger.debug('macOS Native')
           end
         when :windows
-          ::Appium::Core::Windows::Bridge.for self
+          case automation_name
+          when :gecko
+            ::Appium::Logger.debug('Gecko Driver for Windows')
+          else
+            ::Appium::Core::Windows::Bridge.for self
+          end
         when :tizen
           # https://github.com/Samsung/appium-tizen-driver
           ::Appium::Logger.debug('tizen')
@@ -538,6 +547,8 @@ module Appium
           when :mac
             # In this case also can be mac
             ::Appium::Logger.debug('mac')
+          when :gecko  # other general platform
+            ::Appium::Logger.debug('Gecko Driver')
           else
             ::Appium::Logger.warn("No matched driver by platformName: #{device} and automationName: #{automation_name}")
           end

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -513,7 +513,7 @@ module Appium
         when :ios, :tvos
           case automation_name
           when :safari
-            ::Appium::Logger.debug('iOS SafariDriver')
+            ::Appium::Logger.debug('SafariDriver for iOS')
           when :xcuitest
             ::Appium::Core::Ios::Xcuitest::Bridge.for self
           else # default and UIAutomation
@@ -522,7 +522,7 @@ module Appium
         when :mac
           case automation_name
           when :safari
-            ::Appium::Logger.debug('macOS SafariDriver')
+            ::Appium::Logger.debug('SafariDriver for macOS')
           when :gecko
             ::Appium::Logger.debug('Gecko Driver for macOS')
           else

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -494,7 +494,7 @@ module Appium
       private
 
       # @private
-      def extend_for(device:, automation_name:)
+      def extend_for(device:, automation_name:) # rubocop:disable Metrics/CyclomaticComplexity
         extend Appium::Core
         extend Appium::Core::Device
 
@@ -547,7 +547,7 @@ module Appium
           when :mac
             # In this case also can be mac
             ::Appium::Logger.debug('mac')
-          when :gecko  # other general platform
+          when :gecko # other general platform
             ::Appium::Logger.debug('Gecko Driver')
           else
             ::Appium::Logger.warn("No matched driver by platformName: #{device} and automationName: #{automation_name}")


### PR DESCRIPTION
No special change, but for https://github.com/appium/appium-safari-driver

So far, it should be the same as W3C-SafariDriver. It is almost the same as Selenium client.