### PR TITLE
Fixed .install_app args options bug

### DIFF
--- a/lib/appium_lib_core/common/device/app_management.rb
+++ b/lib/appium_lib_core/common/device/app_management.rb
@@ -47,7 +47,7 @@ module Appium
                           grant_permissions: nil)
             args = { appPath: path }
 
-            args[:options] = {} unless options?(replace, timeout, allow_test_packages, use_sdcard, grant_permissions)
+            args[:options] = {} if options?(replace, timeout, allow_test_packages, use_sdcard, grant_permissions)
 
             args[:options][:replace] = replace unless replace.nil?
             args[:options][:timeout] = timeout unless timeout.nil?
@@ -92,8 +92,8 @@ module Appium
 
           private
 
-          def options?(replace, timeout, allow_test_packages, use_sdcard, grant_permissions)
-            replace.nil? || timeout.nil? || allow_test_packages.nil? || use_sdcard.nil? || grant_permissions.nil?
+          def options?(*args)
+            args.compact.any?
           end
         end # module AppManagement
       end # module Device


### PR DESCRIPTION
**What's wrong?**
`args[:options]` object is created only if _all_ optional arguments are present. This leads to error in next lines.

**How to reproduce?**
Call `install_app` method by setting not all optional arguments.