### PR TITLE
feat: bump supported ruby version

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7]
 
     runs-on: ubuntu-latest
 
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         # Does not add 2.7 on Windows so far since a command fails only on Windows
-        ruby: [2.2, 2.3, 2.4, 2.5, 2.6]
+        ruby: [2.4, 2.5, 2.6]
 
     runs-on: windows-latest
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 Metrics/LineLength:
   Max: 128
 Metrics/MethodLength:
@@ -18,9 +18,6 @@ Metrics/ParameterLists:
   Enabled: false
 Lint/NestedMethodDefinition:
   Enabled: false
-# TODO: Replace <<- with <<~ after dropping Ruby 2.2
-Layout/IndentHeredoc:
-  Enabled: false
 Style/ZeroLengthPredicate:
   Enabled: false
 Style/Documentation:
@@ -33,8 +30,7 @@ Style/BracesAroundHashParameters:
   Enabled: false
 Style/SymbolArray:
   Enabled: false
-# TODO: will remove after stopping support 2.2
-Style/NumericPredicate:
+Style/UnpackFirst:
   Enabled: false
 Naming/AccessorMethodName:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Read `release_notes.md` for commit level details.
 
 ## [Unreleased]
 
+Supported Ruby version is 2.4+
+
 ### Enhancements
 
 ### Bug fixes

--- a/appium_lib_core.gemspec
+++ b/appium_lib_core.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'appium_lib_core/version'
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.name          = 'appium_lib_core'
   spec.version       = Appium::Core::VERSION

--- a/test/functional/android/android/device_test.rb
+++ b/test/functional/android/android/device_test.rb
@@ -268,7 +268,7 @@ class AppiumLibCoreTest
       end
 
       def test_get_display_density
-        assert(@driver.get_display_density > 0)
+        assert @driver.get_display_density.positive?
       end
 
       def test_keyevent

--- a/test/functional/android/android/mobile_commands_test.rb
+++ b/test/functional/android/android/mobile_commands_test.rb
@@ -252,7 +252,7 @@ class AppiumLibCoreTest
         skip_as_appium_version '1.10.0'
 
         @driver = @core.start_driver
-        assert(@driver.execute_script('mobile: deviceInfo', {}).size > 0)
+        assert @driver.execute_script('mobile: deviceInfo', {}).size.positive?
       end
 
       private

--- a/test/functional/ios/driver_test.rb
+++ b/test/functional/ios/driver_test.rb
@@ -118,10 +118,10 @@ class AppiumLibCoreTest
     def test_batch
       skip_as_appium_version '1.15.0'
 
-      script = <<-SCRIPT
-const status = await driver.status();
-console.warn('warning message');
-return [status];
+      script = <<~SCRIPT
+        const status = await driver.status();
+        console.warn('warning message');
+        return [status];
       SCRIPT
 
       r = @@driver.execute_driver(script: script, type: 'webdriverio', timeout_ms: 10_000)
@@ -145,11 +145,11 @@ return [status];
     def test_batch_combination_ruby_script
       skip_as_appium_version '1.15.0'
 
-      script = <<-SCRIPT
-console.warn('warning message');
-const element = await driver.findElement('accessibility id', 'Buttons');
-const rect = await driver.getElementRect(element.ELEMENT);
-return [element, rect];
+      script = <<~SCRIPT
+        console.warn('warning message');
+        const element = await driver.findElement('accessibility id', 'Buttons');
+        const rect = await driver.getElementRect(element.ELEMENT);
+        return [element, rect];
       SCRIPT
 
       r = @@driver.execute_driver(script: script)

--- a/test/functional/ios/ios/mobile_commands_test.rb
+++ b/test/functional/ios/ios/mobile_commands_test.rb
@@ -151,7 +151,7 @@ class AppiumLibCoreTest
 
         @driver = @core.start_driver
 
-        assert(@driver.execute_script('mobile: deviceInfo', {}).size > 0)
+        assert @driver.execute_script('mobile: deviceInfo', {}).size.positive?
       end
     end
   end

--- a/test/unit/android/device/w3c/execute_driver_test.rb
+++ b/test/unit/android/device/w3c/execute_driver_test.rb
@@ -29,9 +29,9 @@ class AppiumLibCoreTest
           end
 
           def test_batch_no_timeout
-            script = <<-SCRIPT
-const status = await driver.status();
-return status;
+            script = <<~SCRIPT
+              const status = await driver.status();
+              return status;
             SCRIPT
 
             stub_request(:post, "#{SESSION}/appium/execute_driver")
@@ -48,8 +48,8 @@ return status;
           end
 
           def test_batch
-            script = <<-SCRIPT
-console.warn('warning message');
+            script = <<~SCRIPT
+              console.warn('warning message');
             SCRIPT
 
             stub_request(:post, "#{SESSION}/appium/execute_driver")


### PR DESCRIPTION
Selenium Ruby client will be 2.5 base. (4.0.0a4 was 2.4 base, so let's bump to it for now.)