### PR TITLE
feat: drop forcemjsonwp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Supported Ruby version is 2.4+
 ### Bug fixes
 
 ### Deprecations
+- No longer work with `forceMjsonwp` capability to force the session MJSONWP
 
 ## [3.11.1] - 2020-11-20
 

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -172,9 +172,7 @@ module Appium
           force_mjsonwp = desired_capabilities[FORCE_MJSONWP]
           desired_capabilities = delete_force_mjsonwp(desired_capabilities) unless force_mjsonwp.nil?
 
-          if force_mjsonwp
-            ::Appium::Logger.warn "'forceMjsonwp' no longer works. Sending both W3C and MJSONWP capabilities"
-          end
+          ::Appium::Logger.warn "'forceMjsonwp' no longer works. Sending both W3C and MJSONWP capabilities" if force_mjsonwp
 
           new_caps = add_appium_prefix(desired_capabilities)
           w3c_capabilities = ::Selenium::WebDriver::Remote::W3C::Capabilities.from_oss(new_caps)

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -173,7 +173,7 @@ module Appium
           desired_capabilities = delete_force_mjsonwp(desired_capabilities) unless force_mjsonwp.nil?
 
           if force_mjsonwp
-            ::Appium::Logger.warn "'forceMjsonwp' is no longer available. Sending both W3C and MJSONWP capabilities"
+            ::Appium::Logger.warn "'forceMjsonwp' no longer works. Sending both W3C and MJSONWP capabilities"
           end
 
           new_caps = add_appium_prefix(desired_capabilities)

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -60,30 +60,8 @@ module Appium
         # Creates session handling both OSS and W3C dialects.
         # Copy from Selenium::WebDriver::Remote::Bridge to keep using +merged_capabilities+ for Appium
         #
-        # If +desired_capabilities+ has +forceMjsonwp: true+ in the capability, this bridge works with mjsonwp protocol.
-        # If +forceMjsonwp: false+ or no the capability, it depends on server side whether this bridge works as w3c or mjsonwp.
-        #
         # @param [::Selenium::WebDriver::Remote::W3C::Capabilities, Hash] desired_capabilities A capability
         # @return [::Selenium::WebDriver::Remote::Capabilities, ::Selenium::WebDriver::Remote::W3C::Capabilities]
-        #
-        # @example
-        #
-        #   opts = {
-        #     caps: {
-        #       platformName: :ios,
-        #       automationName: 'XCUITest',
-        #       app: 'test/functional/app/UICatalog.app.zip',
-        #       platformVersion: '11.4',
-        #       deviceName: 'iPhone Simulator',
-        #       useNewWDA: true,
-        #       forceMjsonwp: true
-        #     },
-        #     appium_lib: {
-        #       wait: 30
-        #     }
-        #   }
-        #   core = ::Appium::Core.for(caps)
-        #   driver = core.start_driver #=> driver.dialect == :oss
         #
         # @example
         #
@@ -195,20 +173,18 @@ module Appium
           desired_capabilities = delete_force_mjsonwp(desired_capabilities) unless force_mjsonwp.nil?
 
           if force_mjsonwp
-            {
-              desiredCapabilities: desired_capabilities
-            }
-          else
-            new_caps = add_appium_prefix(desired_capabilities)
-            w3c_capabilities = ::Selenium::WebDriver::Remote::W3C::Capabilities.from_oss(new_caps)
-
-            {
-              desiredCapabilities: desired_capabilities,
-              capabilities: {
-                firstMatch: [w3c_capabilities]
-              }
-            }
+            ::Appium::Logger.warn "'forceMjsonwp' is no longer available. Sending both W3C and MJSONWP capabilities"
           end
+
+          new_caps = add_appium_prefix(desired_capabilities)
+          w3c_capabilities = ::Selenium::WebDriver::Remote::W3C::Capabilities.from_oss(new_caps)
+
+          {
+            desiredCapabilities: desired_capabilities,
+            capabilities: {
+              firstMatch: [w3c_capabilities]
+            }
+          }
         end
       end # class Bridge
     end # class Base

--- a/test/functional/android/webdriver/create_session_test.rb
+++ b/test/functional/android/webdriver/create_session_test.rb
@@ -25,7 +25,7 @@ class AppiumLibCoreTest
 
         driver = core.start_driver
 
-        assert_equal :oss, driver.dialect
+        assert_equal :w3c, driver.dialect
         assert driver.capabilities[:forceMjsonwp].nil?
         assert driver.capabilities['forceMjsonwp'].nil?
 

--- a/test/functional/ios/webdriver/create_session_test.rb
+++ b/test/functional/ios/webdriver/create_session_test.rb
@@ -25,7 +25,7 @@ class AppiumLibCoreTest
 
         driver = core.start_driver
 
-        assert_equal :oss, driver.dialect
+        assert_equal :w3c, driver.dialect
         assert driver.capabilities[:forceMjsonwp].nil?
         assert driver.capabilities['forceMjsonwp'].nil?
       end

--- a/test/unit/common_test.rb
+++ b/test/unit/common_test.rb
@@ -56,27 +56,6 @@ class AppiumLibCoreTest
       }.freeze
 
       def test_create_session_force_mjsonwp
-        response = {
-          status: 0, # To make bridge.dialect == :oss
-          value: RESPONSE_BASE_VALUE
-        }.to_json
-
-        stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
-          .with(body: { desiredCapabilities: CAPS }.to_json)
-          .to_return(headers: Mock::HEADER, status: 200, body: response)
-
-        stub_request(:post, "#{Mock::SESSION}/timeouts/implicit_wait")
-          .with(body: { ms: 0 }.to_json)
-          .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
-
-        driver = ::Appium::Core.for({ caps: CAPS.merge({ forceMjsonwp: true }), appium_lib: {} }).start_driver
-
-        assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-        assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 0 }.to_json, times: 1)
-        driver
-      end
-
-      def test_create_session_force_mjsonwp_false
         response = { value: RESPONSE_BASE_VALUE }.to_json
 
         stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
@@ -88,52 +67,11 @@ class AppiumLibCoreTest
           .with(body: { implicit: 0 }.to_json)
           .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
 
-        driver = ::Appium::Core.for({ caps: CAPS.merge({ forceMjsonwp: false }), appium_lib: {} }).start_driver
+        driver = ::Appium::Core.for({ caps: CAPS.merge({ forceMjsonwp: true }), appium_lib: {} }).start_driver
 
         assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
         assert_requested(:post, "#{Mock::SESSION}/timeouts", body: { implicit: 0 }.to_json, times: 1)
         driver
-      end
-
-      def test_create_session_force_mjsonwp_with_source_package
-        response = {
-          status: 0, # To make bridge.dialect == :oss
-          value: {
-            sessionId: '1234567890',
-            capabilities: {
-              platformName: :android,
-              automationName: 'uiautomator2',
-              app: 'sauce-storage:test/functional/app/api.apk.zip',
-              platformVersion: '7.1.1',
-              deviceName: 'Android Emulator',
-              appPackage: 'io.appium.android.apis'
-            }
-          }
-        }.to_json
-        http_caps = {
-          platformName: :android,
-          automationName: 'uiautomator2',
-          app: 'sauce-storage:test/functional/app/api.apk.zip',
-          platformVersion: '7.1.1',
-          deviceName: 'Android Emulator',
-          appPackage: 'io.appium.android.apis'
-        }
-
-        stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
-          .with(body: { desiredCapabilities: http_caps }.to_json)
-          .to_return(headers: Mock::HEADER, status: 200, body: response)
-
-        stub_request(:post, "#{Mock::SESSION}/timeouts/implicit_wait")
-          .with(body: { ms: 0 }.to_json)
-          .to_return(headers: Mock::HEADER, status: 200, body: { value: nil }.to_json)
-
-        core = ::Appium::Core.for({ caps: http_caps.merge({ forceMjsonwp: true }), appium_lib: {} })
-        core.start_driver
-
-        assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
-        assert_requested(:post, "#{Mock::SESSION}/timeouts/implicit_wait", body: { ms: 0 }.to_json, times: 1)
-
-        assert_equal 'sauce-storage:test/functional/app/api.apk.zip', core.caps[:app]
       end
 
       def test_create_session_w3c


### PR DESCRIPTION
The forceMjsonwp was a temporary solution to keep MJSONWP.
Selenium 4 is going to support only W3C spec, and current Appium already spent a long time with W3C.
Ruby lib will drop lower Ruby versions soon, so it's a good time to drop it as well.