### PR TITLE
feat: allow to add commands dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Read `release_notes.md` for commit level details.
 ## [Unreleased]
 
 ### Enhancements
+- Add `Appium::Core::Base::Driver#add_command` to allow you to add your own command
 
 ### Bug fixes
 

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -22,6 +22,8 @@ module Appium
         # TODO: Remove the forceMjsonwp after Appium server won't need it
         FORCE_MJSONWP = :forceMjsonwp
 
+        attr_reader :commands_store
+
         # Almost same as self.handshake in ::Selenium::WebDriver::Remote::Bridge
         #
         # Implements protocol handshake which:
@@ -49,8 +51,10 @@ module Appium
           case bridge.dialect
           when :oss # for MJSONWP
             Bridge::MJSONWP.new(capabilities, bridge.session_id, **opts)
+            @commands_store = ::Appium::Core::Commands::W3C::COMMANDS.dup
           when :w3c
             Bridge::W3C.new(capabilities, bridge.session_id, **opts)
+            @commands_store = ::Appium::Core::Commands::MJSONWP::COMMANDS.dup
           else
             raise CoreError, 'cannot understand dialect'
           end

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -22,8 +22,6 @@ module Appium
         # TODO: Remove the forceMjsonwp after Appium server won't need it
         FORCE_MJSONWP = :forceMjsonwp
 
-        attr_reader :commands_store
-
         # Almost same as self.handshake in ::Selenium::WebDriver::Remote::Bridge
         #
         # Implements protocol handshake which:
@@ -51,10 +49,8 @@ module Appium
           case bridge.dialect
           when :oss # for MJSONWP
             Bridge::MJSONWP.new(capabilities, bridge.session_id, **opts)
-            @commands_store = ::Appium::Core::Commands::W3C::COMMANDS.dup
           when :w3c
             Bridge::W3C.new(capabilities, bridge.session_id, **opts)
-            @commands_store = ::Appium::Core::Commands::MJSONWP::COMMANDS.dup
           else
             raise CoreError, 'cannot understand dialect'
           end

--- a/lib/appium_lib_core/common/base/bridge/mjsonwp.rb
+++ b/lib/appium_lib_core/common/base/bridge/mjsonwp.rb
@@ -33,8 +33,24 @@ module Appium
           include Device::TouchActions
           include Device::ExecuteDriver
 
+          attr_reader :commands_store
+
+          def initialize(capabilities, session_id, **opts)
+            @commands_store = ::Appium::Core::Commands::MJSONWP::COMMANDS.dup
+            super(capabilities, session_id, opts)
+          end
+
           def commands(command)
-            ::Appium::Core::Commands::MJSONWP::COMMANDS[command]
+            @commands_store[command]
+          end
+
+          # command for Appium 2.0.
+          def add_command(method:, url:, name:, &block)
+            raise ::Appium::Core::Error::ArgumentError, "#{name} is already defined" if @commands_store.key? name
+
+            @commands_store[name] = [method, url]
+
+            ::Appium::Core::Device.add_endpoint_method name, &block
           end
 
           # Returns all available sessions on the Appium server instance

--- a/lib/appium_lib_core/common/base/bridge/mjsonwp.rb
+++ b/lib/appium_lib_core/common/base/bridge/mjsonwp.rb
@@ -33,22 +33,22 @@ module Appium
           include Device::TouchActions
           include Device::ExecuteDriver
 
-          attr_reader :commands_store
+          attr_reader :available_commands
 
           def initialize(capabilities, session_id, **opts)
-            @commands_store = ::Appium::Core::Commands::MJSONWP::COMMANDS.dup
-            super(capabilities, session_id, opts)
+            @available_commands = ::Appium::Core::Commands::MJSONWP::COMMANDS.dup
+            super(capabilities, session_id, **opts)
           end
 
           def commands(command)
-            @commands_store[command]
+            @available_commands[command]
           end
 
           # command for Appium 2.0.
           def add_command(method:, url:, name:, &block)
-            raise ::Appium::Core::Error::ArgumentError, "#{name} is already defined" if @commands_store.key? name
+            raise ::Appium::Core::Error::ArgumentError, "#{name} is already defined" if @available_commands.key? name
 
-            @commands_store[name] = [method, url]
+            @available_commands[name] = [method, url]
 
             ::Appium::Core::Device.add_endpoint_method name, &block
           end

--- a/lib/appium_lib_core/common/base/bridge/w3c.rb
+++ b/lib/appium_lib_core/common/base/bridge/w3c.rb
@@ -34,8 +34,24 @@ module Appium
           include Device::ExecuteDriver
           include Device::Orientation
 
+          attr_reader :commands_store
+
+          def initialize(capabilities, session_id, **opts)
+            @commands_store = ::Appium::Core::Commands::W3C::COMMANDS.dup
+            super(capabilities, session_id, opts)
+          end
+
           def commands(command)
-            ::Appium::Core::Commands::W3C::COMMANDS[command]
+            @commands_store[command]
+          end
+
+          # command for Appium 2.0.
+          def add_command(method:, url:, name:, &block)
+            raise ::Appium::Core::Error::ArgumentError, "#{name} is already defined" if @commands_store.key? name
+
+            @commands_store[name] = [method, url]
+
+            ::Appium::Core::Device.add_endpoint_method name, &block
           end
 
           # Returns all available sessions on the Appium server instance

--- a/lib/appium_lib_core/common/base/bridge/w3c.rb
+++ b/lib/appium_lib_core/common/base/bridge/w3c.rb
@@ -34,22 +34,22 @@ module Appium
           include Device::ExecuteDriver
           include Device::Orientation
 
-          attr_reader :commands_store
+          attr_reader :available_commands
 
           def initialize(capabilities, session_id, **opts)
-            @commands_store = ::Appium::Core::Commands::W3C::COMMANDS.dup
-            super(capabilities, session_id, opts)
+            @available_commands = ::Appium::Core::Commands::W3C::COMMANDS.dup
+            super(capabilities, session_id, **opts)
           end
 
           def commands(command)
-            @commands_store[command]
+            @available_commands[command]
           end
 
           # command for Appium 2.0.
           def add_command(method:, url:, name:, &block)
-            raise ::Appium::Core::Error::ArgumentError, "#{name} is already defined" if @commands_store.key? name
+            raise ::Appium::Core::Error::ArgumentError, "#{name} is already defined" if @available_commands.key? name
 
-            @commands_store[name] = [method, url]
+            @available_commands[name] = [method, url]
 
             ::Appium::Core::Device.add_endpoint_method name, &block
           end

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -117,7 +117,9 @@ module Appium
         #   @driver.test_command(1)
         #
         def add_command(method:, url:, name:, &block)
-          raise ArgumentError, "Available method is either #{AVAILABLE_METHOD}" unless AVAILABLE_METHOD.include? method
+          unless AVAILABLE_METHOD.include? method
+            raise ::Appium::Core::Error::ArgumentError, "Available method is either #{AVAILABLE_METHOD}"
+          end
 
           @bridge.add_command method: method, url: url, name: name, &block
         end

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -76,6 +76,51 @@ module Appium
                                                   path: path)
         end
 
+        AVAILABLE_METHOD = [
+          :get, :head, :post, :put, :delete,
+          :connect, :options, :trace, :patch
+        ].freeze
+        # Define a new custom method to the driver so that you can define your own method for
+        # drivers/plugins in Appium 2.0. Appium 2.0 and its custom drivers/plugins allow you
+        # to define custom commands that are not part of W3C spec.
+        #
+        # @param [Symbol] method HTTP request method as https://www.w3.org/TR/webdriver/#endpoints
+        # @param [string] url The url to URL template as https://www.w3.org/TR/webdriver/#endpoints.
+        #                     ':session_id' is the placeholder of 'session id'.
+        #                     ':id' is the placeholder of 'element id'
+        # @param [Symbol] name The name of method that is called as the driver instance method.
+        # @param [Proc] block The block to involve as the method
+        #
+        # @example
+        #
+        #   @driver.add_command(
+        #     method: :get,
+        #     url: 'session/:session_id/path/to/custom/url',
+        #     name: :test_command
+        #   )
+        #   # Send a GET request to 'session/<session id>/path/to/custom/url'
+        #   @driver.test_command
+        #
+        #
+        #   @driver.add_command(
+        #     method: :post,
+        #     url: 'session/:session_id/path/to/custom/url',
+        #     name: :test_command
+        #   ) do
+        #     def test_command(argument)
+        #       execute(:test_command, {}, { dummy: argument })
+        #     end
+        #   end
+        #   # Send a POST request to 'session/<session id>/path/to/custom/url'
+        #   # with body "{ dummy: 1 }" as JSON object. "1" is the argument.
+        #   @driver.test_command(1)
+        #
+        def add_command(method:, url:, name:, &block)
+          raise ArgumentError, "Available method is either #{AVAILABLE_METHOD}" unless AVAILABLE_METHOD.include? method
+
+          @bridge.add_command method: method, url: url, name: name, &block
+        end
+
         ### Methods for Appium
 
         # Lock the device

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -90,6 +90,7 @@ module Appium
         #                     ':id' is the placeholder of 'element id'
         # @param [Symbol] name The name of method that is called as the driver instance method.
         # @param [Proc] block The block to involve as the method
+        # @raise [ArgumentError] If the given +name+ is already defined or +method+ are invalid value.
         #
         # @example
         #

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -139,6 +139,9 @@ module Appium
             raise ::Appium::Core::Error::ArgumentError, "Available method is either #{AVAILABLE_METHOD}"
           end
 
+          # TODO: Remove this logger
+          ::Appium::Logger.info '[Experimental] this method is experimental for Appium 2.0. This interface may change.'
+
           @bridge.add_command method: method, url: url, name: name, &block
         end
 

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -86,8 +86,9 @@ module Appium
         #
         # @param [Symbol] method HTTP request method as https://www.w3.org/TR/webdriver/#endpoints
         # @param [string] url The url to URL template as https://www.w3.org/TR/webdriver/#endpoints.
-        #                     ':session_id' is the placeholder of 'session id'.
-        #                     ':id' is the placeholder of 'element id'
+        #                     +:session_id+ is the placeholder of 'session id'.
+        #                     Other place holders can be specified with +:+ prefix like +:id+.
+        #                     Then, the +:id+ will be replaced with a given value as the seconds argument of +execute+
         # @param [Symbol] name The name of method that is called as the driver instance method.
         # @param [Proc] block The block to involve as the method
         # @raise [ArgumentError] If the given +name+ is already defined or +method+ are invalid value.
@@ -114,7 +115,24 @@ module Appium
         #   end
         #   # Send a POST request to 'session/<session id>/path/to/custom/url'
         #   # with body "{ dummy: 1 }" as JSON object. "1" is the argument.
+        #   # ':session_id' in the given 'url' is replaced with current 'session id'.
         #   @driver.test_command(1)
+        #
+        #   @driver.add_command(
+        #     method: :post,
+        #     url: 'session/:session_id/element/:id/custom/action',
+        #     name: :test_action_command
+        #   ) do
+        #     def test_action_command(element_id, action)
+        #       execute(:test_action_command, {id: element_id}, { dummy_action: action })
+        #     end
+        #   end
+        #   # Send a POST request to 'session/<session id>/element/<element id>/custom/action'
+        #   # with body "{ dummy_action: #{action} }" as JSON object. "action" is the seconds argument.
+        #   # ':session_id' in the given url is replaced with current 'session id'.
+        #   # ':id' in the given url is replaced with the given 'element_id'.
+        #   e = @driver.find_element :accessibility_id, 'an element'
+        #   @driver.test_action_command(e.ref, 'action')
         #
         def add_command(method:, url:, name:, &block)
           unless AVAILABLE_METHOD.include? method

--- a/lib/appium_lib_core/common/error.rb
+++ b/lib/appium_lib_core/common/error.rb
@@ -27,8 +27,11 @@ module Appium
 
       class UnsupportedOperationError < CoreError; end
 
-      # Server side error
+      # Server side errors
       class ServerError < CoreError; end
+
+      # ruby_lib_core library specific errors
+      class ArgumentError < CoreError; end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ require 'minitest'
 Appium::Logger.level = ::Logger::FATAL # Show Logger logs only they are error
 
 begin
-  Minitest::Reporters.use! [Minitest::Reporters::ProgressReporter.new, Minitest::Reporters::JUnitReporter.new]
+  Minitest::Reporters.use! [Minitest::Reporters::ProgressReporter.new]
 rescue Errno::ENOENT
   # Ignore since Minitest::Reporters::JUnitReporter.new fails in deleting files, sometimes
 end

--- a/test/unit/android/webdriver/mjsonwp/commands_test.rb
+++ b/test/unit/android/webdriver/mjsonwp/commands_test.rb
@@ -28,6 +28,75 @@ class AppiumLibCoreTest
             @driver ||= android_mock_create_session
           end
 
+          def test_add_command
+            @driver.add_command(
+              method: :get,
+              url: 'session/:session_id/path/to/custom/url',
+              name: :test_command
+            )
+
+            assert_equal @driver.respond_to?(:test_command), true
+
+            stub_request(:get, "#{SESSION}/path/to/custom/url")
+              .to_return(headers: HEADER, status: 200, body: { value: 'xxxx' }.to_json)
+
+            @driver.test_command
+
+            assert_requested(:get, "#{SESSION}/path/to/custom/url", times: 1)
+          end
+
+          def test_add_command_block
+            @driver.add_command(
+              method: :post,
+              url: 'session/:session_id/path/to/custom/url',
+              name: :test_command
+            ) do
+              def test_command(argument)
+                execute(:test_command, {}, { dummy: argument })
+              end
+            end
+
+            assert_equal @driver.respond_to?(:test_command), true
+
+            stub_request(:post, "#{SESSION}/path/to/custom/url")
+              .with(body: { dummy: 1 }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: nil }.to_json)
+
+            @driver.test_command(1)
+
+            assert_requested(:post, "#{SESSION}/path/to/custom/url", times: 1)
+          end
+
+          def test_add_command_error
+            assert_raises ::Appium::Core::Error::ArgumentError do
+              @driver.add_command(
+                method: :invalid_method,
+                url: 'session/:session_id/path/to/custom/url',
+                name: :test_command
+              )
+            end
+          end
+
+          def test_add_command_already_defined
+            @driver.add_command(
+              method: :get,
+              url: 'session/:session_id/path/to/custom/url',
+              name: :test_command
+            )
+
+            assert_equal @driver.respond_to?(:test_command), true
+
+            assert_raises ::Appium::Core::Error::ArgumentError do
+              @driver.add_command(
+                method: :get,
+                url: 'session/:session_id/path/to/custom/url',
+                name: :test_command
+              )
+            end
+
+            assert_equal @driver.respond_to?(:test_command), true
+          end
+
           def test_no_session_id
             response = {
               status: 0, # To make bridge.dialect == :oss

--- a/test/unit/android/webdriver/w3c/commands_test.rb
+++ b/test/unit/android/webdriver/w3c/commands_test.rb
@@ -68,7 +68,7 @@ class AppiumLibCoreTest
           end
 
           def test_add_command_error
-            assert_raises ArgumentError do
+            assert_raises ::Appium::Core::Error::ArgumentError do
               @driver.add_command(
                 method: :invalid_method,
                 url: 'session/:session_id/path/to/custom/url',
@@ -86,7 +86,7 @@ class AppiumLibCoreTest
 
             assert_equal @driver.respond_to?(:test_command), true
 
-            assert_raises ArgumentError do
+            assert_raises ::Appium::Core::Error::ArgumentError do
               @driver.add_command(
                 method: :get,
                 url: 'session/:session_id/path/to/custom/url',

--- a/test/unit/android/webdriver/w3c/commands_test.rb
+++ b/test/unit/android/webdriver/w3c/commands_test.rb
@@ -77,6 +77,26 @@ class AppiumLibCoreTest
             end
           end
 
+          def test_add_command_already_defined
+            @driver.add_command(
+              method: :get,
+              url: 'session/:session_id/path/to/custom/url',
+              name: :test_command
+            )
+
+            assert_equal @driver.respond_to?(:test_command), true
+
+            assert_raises ArgumentError do
+              @driver.add_command(
+                method: :get,
+                url: 'session/:session_id/path/to/custom/url',
+                name: :test_command
+              )
+            end
+
+            assert_equal @driver.respond_to?(:test_command), true
+          end
+
           def test_no_session_id
             response = {
               value: {

--- a/test/unit/android/webdriver/w3c/commands_test.rb
+++ b/test/unit/android/webdriver/w3c/commands_test.rb
@@ -28,6 +28,55 @@ class AppiumLibCoreTest
             @driver ||= android_mock_create_session_w3c
           end
 
+          def test_add_command
+            @driver.add_command(
+              method: :get,
+              url: 'session/:session_id/path/to/custom/url',
+              name: :test_command
+            )
+
+            assert_equal @driver.respond_to?(:test_command), true
+
+            stub_request(:get, "#{SESSION}/path/to/custom/url")
+              .to_return(headers: HEADER, status: 200, body: { value: 'xxxx' }.to_json)
+
+            @driver.test_command
+
+            assert_requested(:get, "#{SESSION}/path/to/custom/url", times: 1)
+          end
+
+          def test_add_command_block
+            @driver.add_command(
+              method: :post,
+              url: 'session/:session_id/path/to/custom/url',
+              name: :test_command
+            ) do
+              def test_command(argument)
+                execute(:test_command, {}, { dummy: argument })
+              end
+            end
+
+            assert_equal @driver.respond_to?(:test_command), true
+
+            stub_request(:post, "#{SESSION}/path/to/custom/url")
+              .with(body: { dummy: 1 }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: nil }.to_json)
+
+            @driver.test_command(1)
+
+            assert_requested(:post, "#{SESSION}/path/to/custom/url", times: 1)
+          end
+
+          def test_add_command_error
+            assert_raises ArgumentError do
+              @driver.add_command(
+                method: :invalid_method,
+                url: 'session/:session_id/path/to/custom/url',
+                name: :test_command
+              )
+            end
+          end
+
           def test_no_session_id
             response = {
               value: {


### PR DESCRIPTION
https://github.com/appium/ruby_lib_core/issues/306 by exposing `::Appium::Core::Device.add_endpoint_method` as a public method of a driver instance