### PR TITLE
feat: do not restrict options in install_app

### DIFF
--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -625,6 +625,9 @@ module Appium
         # @param [Boolean] grant_permissions Only for Android. whether to automatically grant application permissions
         #                                    on Android 6+ after the installation completes. +false+ by default
         #
+        # Other parameters such as https://github.com/appium/appium-xcuitest-driver#mobile-installapp also can be set.
+        # Then, arguments in snake case will be camel case as its request parameters.
+        #
         # @example
         #
         #   @driver.install_app("/path/to/test.apk")

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -609,7 +609,9 @@ module Appium
           @bridge.background_app(duration)
         end
 
-        # Install the given app onto the device
+        # Install the given app onto the device.
+        # Each options can be snake-case or camel-case. Snake-cases will be converted to camel-case
+        # as options value.
         #
         # @param [String] path The absolute local path or remote http URL to an .ipa or .apk file,
         #                      or a .zip containing one of these.
@@ -629,19 +631,15 @@ module Appium
         #   @driver.install_app("/path/to/test.apk", replace: true, timeout: 20000, allow_test_packages: true,
         #                       use_sdcard: false, grant_permissions: false)
         #
-        def install_app(path,
-                        replace: nil,
-                        timeout: nil,
-                        allow_test_packages: nil,
-                        use_sdcard: nil,
-                        grant_permissions: nil)
-          @bridge.install_app(path,
-                              replace: replace,
-                              timeout: timeout,
-                              allow_test_packages: allow_test_packages,
-                              use_sdcard: use_sdcard,
-                              grant_permissions: grant_permissions)
+        def install_app(path, options = {})
+          options = options.transform_keys {|k| k.to_s.gsub(/_./) {|v| v.split('_')[1].capitalize} } unless options.nil?
+          @bridge.install_app(path, options)
         end
+
+        # def capitalize(s)
+        #   chars =
+        #   chars[1:].map(&:capitalize).join
+        # end
 
         # @param [Strong] app_id BundleId for iOS or package name for Android
         # @param [Boolean] keep_data Only for Android. Whether to keep application data and caches after it is uninstalled.

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -632,7 +632,7 @@ module Appium
         #                       use_sdcard: false, grant_permissions: false)
         #
         def install_app(path, options = {})
-          options = options.transform_keys {|k| k.to_s.gsub(/_./) {|v| v.split('_')[1].capitalize} } unless options.nil?
+          options = options.transform_keys { |key| key.to_s.gsub(/_./) { |v| v[1..].capitalize } } unless options.nil?
           @bridge.install_app(path, options)
         end
 

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -630,9 +630,10 @@ module Appium
         #   @driver.install_app("/path/to/test.apk")
         #   @driver.install_app("/path/to/test.apk", replace: true, timeout: 20000, allow_test_packages: true,
         #                       use_sdcard: false, grant_permissions: false)
+        #   @driver.install_app("/path/to/test.ipa", timeoutMs: 20000)
         #
         def install_app(path, options = {})
-          options = options.transform_keys { |key| key.to_s.gsub(/_./) { |v| v[1..].capitalize } } unless options.nil?
+          options = options.transform_keys { |key| key.to_s.gsub(/_./) { |v| v[1].upcase } } unless options.nil?
           @bridge.install_app(path, options)
         end
 

--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -632,7 +632,7 @@ module Appium
         #                       use_sdcard: false, grant_permissions: false)
         #   @driver.install_app("/path/to/test.ipa", timeoutMs: 20000)
         #
-        def install_app(path, options = {})
+        def install_app(path, **options)
           options = options.transform_keys { |key| key.to_s.gsub(/_./) { |v| v[1].upcase } } unless options.nil?
           @bridge.install_app(path, options)
         end

--- a/lib/appium_lib_core/common/device/app_management.rb
+++ b/lib/appium_lib_core/common/device/app_management.rb
@@ -39,21 +39,9 @@ module Appium
             raise NotImplementedError
           end
 
-          def install_app(path,
-                          replace: nil,
-                          timeout: nil,
-                          allow_test_packages: nil,
-                          use_sdcard: nil,
-                          grant_permissions: nil)
+          def install_app(path, options = {})
             args = { appPath: path }
-
-            args[:options] = {} if options?(replace, timeout, allow_test_packages, use_sdcard, grant_permissions)
-
-            args[:options][:replace] = replace unless replace.nil?
-            args[:options][:timeout] = timeout unless timeout.nil?
-            args[:options][:allowTestPackages] = allow_test_packages unless allow_test_packages.nil?
-            args[:options][:useSdcard] = use_sdcard unless use_sdcard.nil?
-            args[:options][:grantPermissions] = grant_permissions unless grant_permissions.nil?
+            args[:options] = options unless options.empty?
 
             execute :install_app, {}, args
           end

--- a/test/unit/android/device/w3c/app_management_test.rb
+++ b/test/unit/android/device/w3c/app_management_test.rb
@@ -138,7 +138,8 @@ class AppiumLibCoreTest
                               timeout: 20_000,
                               allowTestPackages: true,
                               useSdcard: false,
-                              grantPermissions: false
+                              grantPermissions: false,
+                              timeoutMs: 10_000  # for iOS
                             } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 
@@ -147,7 +148,8 @@ class AppiumLibCoreTest
                                 timeout: 20_000,
                                 allow_test_packages: true,
                                 use_sdcard: false,
-                                grant_permissions: false
+                                grant_permissions: false,
+                                timeoutMs: 10_000
 
             assert_requested(:post, "#{SESSION}/appium/device/install_app", times: 1)
           end

--- a/test/unit/android/device/w3c/app_management_test.rb
+++ b/test/unit/android/device/w3c/app_management_test.rb
@@ -148,8 +148,8 @@ class AppiumLibCoreTest
                                 timeout: 20_000,
                                 allow_test_packages: true,
                                 use_sdcard: false,
-                                grant_permissions: false,
-                                timeoutMs: 10_000
+                                grantPermissions: false,
+                                timeout_ms: 10_000
 
             assert_requested(:post, "#{SESSION}/appium/device/install_app", times: 1)
           end

--- a/test/unit/android/device/w3c/app_management_test.rb
+++ b/test/unit/android/device/w3c/app_management_test.rb
@@ -135,11 +135,11 @@ class AppiumLibCoreTest
               .with(body: { appPath: 'app_path',
                             options: {
                               replace: true,
-                              timeout: 20_000,
+                              timeout: 20_000, # for Android
                               allowTestPackages: true,
                               useSdcard: false,
                               grantPermissions: false,
-                              timeoutMs: 10_000  # for iOS
+                              timeoutMs: 10_000 # for iOS
                             } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: '' }.to_json)
 


### PR DESCRIPTION
xcuitest driver wants to allow options in https://github.com/appium/appium-xcuitest-driver#mobile-installapp for `install_app` as well.

This will need doc more.