### PR TITLE
fix: make bridge attribute non-private for flutter finder

### DIFF
--- a/lib/appium_lib_core/common/base/driver.rb
+++ b/lib/appium_lib_core/common/base/driver.rb
@@ -41,11 +41,11 @@ module Appium
 
         include ::Appium::Core::Waitable
 
-        private
-
         # Private API.
         # Do not use this for general use. Used by flutter driver to get bridge for creating a new element
         attr_reader :bridge
+
+        private
 
         def initialize(bridge: nil, listener: nil, **opts)
           # For ::Appium::Core::Waitable


### PR DESCRIPTION
A regression in v5 for https://github.com/appium-userland/appium-flutter-driver/tree/master/finder/ruby/lib