### PR TITLE
fix: execute cdp for chrome session

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,9 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
-  Max: 14
+  Max: 15
 Metrics/PerceivedComplexity:
-  Max: 14
+  Max: 15
 Metrics/ParameterLists:
   Enabled: false
 Lint/NestedMethodDefinition:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,9 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
-  Max: 15
+  Max: 14
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 14
 Metrics/ParameterLists:
   Enabled: false
 Lint/NestedMethodDefinition:

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -423,8 +423,8 @@ module Appium
                 # for selenium-webdriver compatibility in chrome browser session.
                 # This may be needed in selenium-webdriver 4.8 or over? (around the version)
                 # when a session starts browserName: 'chrome' for bridge.
-                def send_command(cmd:, params:)
-                  execute :chrome_send_command, {}, { cmd: cmd, params: params }
+                def send_command(command_params)
+                  execute :chrome_send_command, {}, command_params
                 end
               end
             end

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -302,6 +302,10 @@ module Appium
         #   @driver.execute_cdp 'Page.captureScreenshot', quality: 50, format: 'jpeg'
         #   @driver.execute_cdp 'Page.getResourceTree'
         #
+        #   # for Ruby 2,7 and 3+ compatibility
+        #   params = {'timezoneId': 'Asia/Tokyo'}
+        #   driver.execute_cdp 'Emulation.setTimezoneOverride', **params
+        #
 
         ####
         ## class << self

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -413,10 +413,19 @@ module Appium
 
             ::Appium::Core::Device.add_endpoint_method(:execute_cdp) do
               # SeleniumWebdriver could already define this method
-              return if method_defined? :execute_cdp
+              unless method_defined? :execute_cdp
+                def execute_cdp(cmd, **params)
+                  execute :chrome_send_command, {}, { cmd: cmd, params: params }
+                end
+              end
 
-              def execute_cdp(cmd, **params)
-                execute :chrome_send_command, {}, { cmd: cmd, params: params }
+              unless method_defined? :send_command
+                # for selenium-webdriver compatibility in chrome browser session.
+                # This may be needed in selenium-webdriver 4.8 or over? (around the version)
+                # when a session starts browserName: 'chrome' for bridge.
+                def send_command(cmd:, params:)
+                  execute :chrome_send_command, {}, { cmd: cmd, params: params }
+                end
               end
             end
 

--- a/lib/appium_lib_core/android/device.rb
+++ b/lib/appium_lib_core/android/device.rb
@@ -413,19 +413,10 @@ module Appium
 
             ::Appium::Core::Device.add_endpoint_method(:execute_cdp) do
               # SeleniumWebdriver could already define this method
-              unless method_defined? :execute_cdp
-                def execute_cdp(cmd, **params)
-                  execute :chrome_send_command, {}, { cmd: cmd, params: params }
-                end
-              end
+              return if method_defined? :execute_cdp
 
-              unless method_defined? :send_command
-                # for selenium-webdriver compatibility in chrome browser session.
-                # This may be needed in selenium-webdriver 4.8 or over? (around the version)
-                # when a session starts browserName: 'chrome' for bridge.
-                def send_command(command_params)
-                  execute :chrome_send_command, {}, command_params
-                end
+              def execute_cdp(cmd, **params)
+                execute :chrome_send_command, {}, { cmd: cmd, params: params }
               end
             end
 

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -357,11 +357,6 @@ module Appium
           execute :take_element_screenshot, id: element_id
         end
 
-        # for selenium-webdriver compatibility for chrome browser
-        # def send_command(cmd:, params:)
-        #   execute :chrome_send_command, {}, { cmd: cmd, params: params }
-        # end
-
         private
 
         def unwrap_script_result(arg)

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -357,6 +357,11 @@ module Appium
           execute :take_element_screenshot, id: element_id
         end
 
+        # for selenium-webdriver compatibility for chrome browser
+        # def send_command(cmd:, params:)
+        #   execute :chrome_send_command, {}, { cmd: cmd, params: params }
+        # end
+
         private
 
         def unwrap_script_result(arg)

--- a/lib/appium_lib_core/common/base/bridge.rb
+++ b/lib/appium_lib_core/common/base/bridge.rb
@@ -357,6 +357,15 @@ module Appium
           execute :take_element_screenshot, id: element_id
         end
 
+        # for selenium-webdriver compatibility in chrome browser session.
+        # This may be needed in selenium-webdriver 4.8 or over? (around the version)
+        # when a session starts browserName: 'chrome' for bridge.
+        # This method is not only for Android, but also chrome desktop browser as well.
+        # So this bridge itself does not restrict the target module.
+        def send_command(command_params)
+          execute :chrome_send_command, {}, command_params
+        end
+
         private
 
         def unwrap_script_result(arg)

--- a/test/unit/android/device/w3c/execute_cdp_test.rb
+++ b/test/unit/android/device/w3c/execute_cdp_test.rb
@@ -34,7 +34,7 @@ class AppiumLibCoreTest
 
             assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
           end
-        end # class DeviceLockTest
+        end
 
         class ExecuteCDPChromeTest < Minitest::Test
           include AppiumLibCoreTest::Mock
@@ -50,7 +50,7 @@ class AppiumLibCoreTest
 
             assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
           end
-        end # class DeviceLockTest
+        end
       end # module W3C
     end # module Device
   end # module Android

--- a/test/unit/android/device/w3c/execute_cdp_test.rb
+++ b/test/unit/android/device/w3c/execute_cdp_test.rb
@@ -30,7 +30,7 @@ class AppiumLibCoreTest
               .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Asia/Tokyo' } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: {} }.to_json)
 
-            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Asia/Tokyo' }
+            @driver.execute_cdp 'Emulation.setTimezoneOverride', 'timezoneId': 'Asia/Tokyo'
 
             assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
           end
@@ -46,7 +46,7 @@ class AppiumLibCoreTest
               .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Asia/Tokyo' } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: {} }.to_json)
 
-            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Asia/Tokyo' }
+            @driver.execute_cdp 'Emulation.setTimezoneOverride', 'timezoneId': 'Asia/Tokyo'
 
             assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
           end

--- a/test/unit/android/device/w3c/execute_cdp_test.rb
+++ b/test/unit/android/device/w3c/execute_cdp_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'test_helper'
+require 'webmock/minitest'
+
+# $ rake test:unit TEST=test/unit/android/device/w3c/commands_test.rb
+class AppiumLibCoreTest
+  module Android
+    module Device
+      module W3C
+        class ExecuteCDPAndroidTest < Minitest::Test
+          include AppiumLibCoreTest::Mock
+          def test_execute_cdp
+            @core = ::Appium::Core.for(Caps.android)
+            @driver = android_mock_create_session_w3c
+
+            stub_request(:post, "#{SESSION}/goog/cdp/execute")
+              .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Japan' } }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: {} }.to_json)
+
+            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Japan' }
+
+            assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
+          end
+        end # class DeviceLockTest
+
+        class ExecuteCDPChromeTest < Minitest::Test
+          include AppiumLibCoreTest::Mock
+          def test_execute_cdp_chrome
+            @core = ::Appium::Core.for(Caps.android)
+            @driver = android_chrome_mock_create_session_w3c
+
+            stub_request(:post, "#{SESSION}/goog/cdp/execute")
+              .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Japan' } }.to_json)
+              .to_return(headers: HEADER, status: 200, body: { value: {} }.to_json)
+
+            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Japan' }
+
+            assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
+          end
+        end # class DeviceLockTest
+      end # module W3C
+    end # module Device
+  end # module Android
+end # class AppiumLibCoreTest

--- a/test/unit/android/device/w3c/execute_cdp_test.rb
+++ b/test/unit/android/device/w3c/execute_cdp_test.rb
@@ -27,10 +27,10 @@ class AppiumLibCoreTest
             @driver = android_mock_create_session_w3c
 
             stub_request(:post, "#{SESSION}/goog/cdp/execute")
-              .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Japan' } }.to_json)
+              .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Asia/Tokyo' } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: {} }.to_json)
 
-            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Japan' }
+            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Asia/Tokyo' }
 
             assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
           end
@@ -43,10 +43,10 @@ class AppiumLibCoreTest
             @driver = android_chrome_mock_create_session_w3c
 
             stub_request(:post, "#{SESSION}/goog/cdp/execute")
-              .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Japan' } }.to_json)
+              .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Asia/Tokyo' } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: {} }.to_json)
 
-            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Japan' }
+            @driver.execute_cdp 'Emulation.setTimezoneOverride', { 'timezoneId': 'Asia/Tokyo' }
 
             assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
           end

--- a/test/unit/android/device/w3c/execute_cdp_test.rb
+++ b/test/unit/android/device/w3c/execute_cdp_test.rb
@@ -27,10 +27,10 @@ class AppiumLibCoreTest
             @driver = android_mock_create_session_w3c
 
             stub_request(:post, "#{SESSION}/goog/cdp/execute")
-              .with(body: { cmd: 'Emulation.setTimezoneOverride', params: { timezoneId: 'Asia/Tokyo' } }.to_json)
+              .with(body: { cmd: 'Page.captureScreenshot', params: { quality: 50, format: 'jpeg' } }.to_json)
               .to_return(headers: HEADER, status: 200, body: { value: {} }.to_json)
 
-            @driver.execute_cdp 'Emulation.setTimezoneOverride', 'timezoneId': 'Asia/Tokyo'
+            @driver.execute_cdp 'Page.captureScreenshot', quality: 50, format: 'jpeg'
 
             assert_requested(:post, "#{SESSION}/goog/cdp/execute", times: 1)
           end


### PR DESCRIPTION
```
ERROR AppiumLibCoreTest::Android::Device::W3C::ExecuteCDPTest#test_execute_cdp_chrome (1.38s)
Minitest::UnexpectedError:         NoMethodError: undefined method `send_command' for #<Appium::Core::Base::Bridge:0x00007ff396051ba8>
        Did you mean?  add_command
                       test_command
            /Users/kazu/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/selenium-webdriver-4.9.0/lib/selenium/webdriver/common/driver_extensions/has_cdp.rb:31:in `execute_cdp'
            /Users/kazu/GitHub/ruby_lib_core/test/unit/android/device/w3c/execute_cdp_test.rb:49:in `test_execute_cdp_chrome'
```