### PR TITLE
refactor: define UA in requests is sufficisnet instead

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -224,3 +224,5 @@ Style/RedundantInitialize: # new in 1.27
   Enabled: true
 Style/RedundantStringEscape: # new in 1.37
   Enabled: true
+Style/RegexpLiteral:
+  Enabled: false

--- a/lib/appium_lib_core/common/base/http_default.rb
+++ b/lib/appium_lib_core/common/base/http_default.rb
@@ -27,13 +27,6 @@ module Appium
         end
 
         class Default < Selenium::WebDriver::Remote::Http::Default
-          DEFAULT_HEADERS = {
-            'Accept' => CONTENT_TYPE,
-            'Content-Type' => "#{CONTENT_TYPE}; charset=UTF-8",
-            'User-Agent' =>
-              "appium/ruby_lib_core/#{VERSION} (#{::Selenium::WebDriver::Remote::Http::Common::DEFAULT_HEADERS['User-Agent']})"
-          }.freeze
-
           attr_reader :additional_headers
 
           # override
@@ -64,6 +57,13 @@ module Appium
             @server_url = URI.parse "#{scheme}://#{host}:#{port}#{path}"
           end
 
+          def request(verb, url, headers, payload, redirects = 0)
+            headers['User-Agent'] = "appium/ruby_lib_core/#{VERSION} (#{headers['User-Agent']})"
+            headers  = headers.merge @additional_headers unless @additional_headers.empty?
+
+            super(verb, url, headers, payload, redirects)
+          end
+
           private
 
           def validate_url_param(scheme, host, port, path)
@@ -72,30 +72,6 @@ module Appium
             message = "Given parameters are scheme: '#{scheme}', host: '#{host}', port: '#{port}', path: '#{path}'"
             ::Appium::Logger.debug(message)
             false
-          end
-
-          public
-
-          # override to use default header
-          # https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/remote/http/common.rb#L46
-          def call(verb, url, command_hash)
-            url      = server_url.merge(url) unless url.is_a?(URI)
-            headers  = DEFAULT_HEADERS.dup
-            headers  = headers.merge @additional_headers unless @additional_headers.empty?
-            headers['Cache-Control'] = 'no-cache' if verb == :get
-
-            if command_hash
-              payload                   = JSON.generate(command_hash)
-              headers['Content-Length'] = payload.bytesize.to_s if [:post, :put].include?(verb)
-            elsif verb == :post
-              payload = '{}'
-              headers['Content-Length'] = '2'
-            end
-
-            ::Appium::Logger.info("   >>> #{url} | #{payload}")
-            ::Appium::Logger.info("     > #{headers.inspect}")
-
-            request verb, url, headers, payload
           end
         end
       end

--- a/lib/appium_lib_core/common/base/http_default.rb
+++ b/lib/appium_lib_core/common/base/http_default.rb
@@ -59,7 +59,7 @@ module Appium
 
           def request(verb, url, headers, payload, redirects = 0)
             headers['User-Agent'] = "appium/ruby_lib_core/#{VERSION} (#{headers['User-Agent']})"
-            headers  = headers.merge @additional_headers unless @additional_headers.empty?
+            headers = headers.merge @additional_headers unless @additional_headers.empty?
 
             super(verb, url, headers, payload, redirects)
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -452,10 +452,34 @@ class AppiumLibCoreTest
       driver = @core.start_driver
 
       assert_equal({}, driver.send(:bridge).http.additional_headers)
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
+      assert_requested(
+        :post,
+        'http://127.0.0.1:4723/wd/hub/session',
+        headers: {
+          'X-Idempotency-Key' => /.+/,
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        times: 1
+      )
 
-      assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 5_000 }.to_json, times: 1)
-      assert_not_requested(:post, "#{SESSION}/timeouts", headers: { 'X-Idempotency-Key' => /.+/ }, body: { implicit: 5_000 }.to_json, times: 1)
+      assert_requested(
+        :post,
+        "#{SESSION}/timeouts",
+        headers: {
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        body: { implicit: 5_000 }.to_json,
+        times: 1
+      )
+      assert_not_requested(
+        :post,
+        "#{SESSION}/timeouts",
+        headers: { 'X-Idempotency-Key' => /.+/ },
+        body: { implicit: 5_000 }.to_json,
+        times: 1
+      )
       driver
     end
 
@@ -483,10 +507,34 @@ class AppiumLibCoreTest
       driver = @core.start_driver
 
       assert_equal({}, driver.send(:bridge).http.additional_headers)
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
+      assert_requested(
+        :post,
+        'http://127.0.0.1:4723/wd/hub/session',
+        headers: {
+          'X-Idempotency-Key' => /.+/,
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        times: 1
+      )
 
-      assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 5_000 }.to_json, times: 1)
-      assert_not_requested(:post, "#{SESSION}/timeouts", headers: { 'X-Idempotency-Key' => /.+/ }, body: { implicit: 5_000 }.to_json, times: 1)
+      assert_requested(
+        :post,
+        "#{SESSION}/timeouts",
+        headers: {
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        body: { implicit: 5_000 }.to_json,
+        times: 1
+      )
+      assert_not_requested(
+        :post,
+        "#{SESSION}/timeouts",
+        headers: { 'X-Idempotency-Key' => /.+/ },
+        body: { implicit: 5_000 }.to_json,
+        times: 1
+      )
       driver
     end
 
@@ -512,7 +560,16 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
+      assert_requested(
+        :post,
+        'http://127.0.0.1:4723/wd/hub/session',
+        headers: {
+          'X-Idempotency-Key' => /.+/,
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        times: 1
+      )
       driver
     end
 
@@ -534,7 +591,16 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
+      assert_requested(
+        :post,
+        'http://127.0.0.1:4723/wd/hub/session',
+        headers: {
+          'X-Idempotency-Key' => /.+/,
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        times: 1
+      )
       driver
     end
 
@@ -556,7 +622,16 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
+      assert_requested(
+        :post,
+        'http://127.0.0.1:4723/wd/hub/session',
+        headers: {
+          'X-Idempotency-Key' => /.+/,
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        times: 1
+      )
       driver
     end
 
@@ -576,7 +651,16 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
+      assert_requested(
+        :post,
+        'http://127.0.0.1:4723/wd/hub/session',
+        headers: {
+          'X-Idempotency-Key' => /.+/,
+          'Content-Type' => 'application/json; charset=UTF-8',
+          'User-Agent' => /appium\/ruby_lib_core\/.+/
+        },
+        times: 1
+      )
       driver
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -443,7 +443,6 @@ class AppiumLibCoreTest
       }.to_json
 
       stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
-        .with(headers: { 'X-Idempotency-Key' => /.+/ })
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts")
@@ -453,8 +452,10 @@ class AppiumLibCoreTest
       driver = @core.start_driver
 
       assert_equal({}, driver.send(:bridge).http.additional_headers)
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
+      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
+
       assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 5_000 }.to_json, times: 1)
+      assert_not_requested(:post, "#{SESSION}/timeouts", headers: { 'X-Idempotency-Key' => /.+/ }, body: { implicit: 5_000 }.to_json, times: 1)
       driver
     end
 
@@ -473,7 +474,6 @@ class AppiumLibCoreTest
       }.to_json
 
       stub_request(:post, 'http://127.0.0.1:4723/wd/hub/session')
-        .with(headers: { 'X-Idempotency-Key' => /.+/ })
         .to_return(headers: HEADER, status: 200, body: response)
 
       stub_request(:post, "#{SESSION}/timeouts")
@@ -483,8 +483,10 @@ class AppiumLibCoreTest
       driver = @core.start_driver
 
       assert_equal({}, driver.send(:bridge).http.additional_headers)
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
+      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
+
       assert_requested(:post, "#{SESSION}/timeouts", body: { implicit: 5_000 }.to_json, times: 1)
+      assert_not_requested(:post, "#{SESSION}/timeouts", headers: { 'X-Idempotency-Key' => /.+/ }, body: { implicit: 5_000 }.to_json, times: 1)
       driver
     end
 
@@ -510,7 +512,7 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
+      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
       driver
     end
 
@@ -532,7 +534,7 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
+      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
       driver
     end
 
@@ -554,7 +556,7 @@ class AppiumLibCoreTest
 
       driver = @core.start_driver
 
-      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', times: 1)
+      assert_requested(:post, 'http://127.0.0.1:4723/wd/hub/session', headers: { 'X-Idempotency-Key' => /.+/ }, times: 1)
       driver
     end
 


### PR DESCRIPTION
Refer to https://github.com/SeleniumHQ/selenium/pull/12141#discussion_r1217364496

Current ruby_lib_core's headers modification way is not good as monchy-pactch. Actually the Watir way is sufficient and makes more sense for this usage. Let me modify current implementation to reduce a monkey patche