### PR TITLE
feat: RBS setup for core appium library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 .idea
 
 .coverage
+
+# for RBS
+/.gem_rbs_collection/

--- a/Rakefile
+++ b/Rakefile
@@ -117,3 +117,9 @@ RuboCop::RakeTask.new(:rubocop) do |t|
   t.options = %w(-D)
   t.fail_on_error = true
 end
+
+desc('Run Steep type check')
+task :steep do
+  system('steep check')
+end
+

--- a/Rakefile
+++ b/Rakefile
@@ -122,4 +122,3 @@ desc('Run Steep type check')
 task :steep do
   system('steep check')
 end
-

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+target :lib do
+  signature 'sig'
+  check 'lib' # Directory name
+
+  # Standard libraries used in the project
+  library(
+    'forwardable'
+  )
+end

--- a/appium_lib_core.gemspec
+++ b/appium_lib_core.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '1.65.0'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'steep', '~> 1.7.0'
   spec.add_development_dependency 'webmock', '~> 3.23.0'
   spec.add_development_dependency 'yard', '~> 0.9.11'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,0 +1,168 @@
+---
+path: ".gem_rbs_collection"
+gems:
+- name: addressable
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ast
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: base64
+  version: '0'
+  source:
+    type: stdlib
+- name: bigdecimal
+  version: '0'
+  source:
+    type: stdlib
+- name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: hashdiff
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: json
+  version: '0'
+  source:
+    type: stdlib
+- name: logger
+  version: '0'
+  source:
+    type: stdlib
+- name: minitest
+  version: '0'
+  source:
+    type: stdlib
+- name: monitor
+  version: '0'
+  source:
+    type: stdlib
+- name: mutex_m
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
+  version: '0'
+  source:
+    type: stdlib
+- name: parallel
+  version: '1.20'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: parser
+  version: '3.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rainbow
+  version: '3.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rake
+  version: '13.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: regexp_parser
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ripper
+  version: '0'
+  source:
+    type: stdlib
+- name: rubocop
+  version: '1.57'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubocop-ast
+  version: '1.30'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubyzip
+  version: '2.3'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: simplecov
+  version: '0.22'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: strscan
+  version: '0'
+  source:
+    type: stdlib
+- name: thor
+  version: '1.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: webmock
+  version: '3.19'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: yard
+  version: '0.9'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,11 +1,14 @@
 ---
-sources:
-- name: ruby/gem_rbs_collection
-  remote: https://github.com/ruby/gem_rbs_collection.git
-  revision: main
-  repo_dir: gems
 path: ".gem_rbs_collection"
 gems:
+- name: activesupport
+  version: '7.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: addressable
   version: '2.8'
   source:
@@ -30,8 +33,56 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: concurrent-ruby
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: connection_pool
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: csv
+  version: '0'
+  source:
+    type: stdlib
+- name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: erb
+  version: '0'
+  source:
+    type: stdlib
+- name: ffi
+  version: 1.17.0
+  source:
+    type: rubygems
+- name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: forwardable
+  version: '0'
+  source:
+    type: stdlib
 - name: hashdiff
   version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: i18n
+  version: '1.10'
   source:
     type: git
     name: ruby/gem_rbs_collection
@@ -42,11 +93,31 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: listen
+  version: '3.9'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: logger
   version: '0'
   source:
     type: stdlib
 - name: minitest
+  version: '0'
+  source:
+    type: stdlib
+- name: monitor
+  version: '0'
+  source:
+    type: stdlib
+- name: mutex_m
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
   version: '0'
   source:
     type: stdlib
@@ -90,6 +161,10 @@ gems:
     revision: 3670834268f4ea9c10aefeffae7e072b51256375
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: ripper
+  version: '0'
+  source:
+    type: stdlib
 - name: rubocop
   version: '1.57'
   source:
@@ -114,6 +189,10 @@ gems:
     revision: 3670834268f4ea9c10aefeffae7e072b51256375
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: securerandom
+  version: '0'
+  source:
+    type: stdlib
 - name: simplecov
   version: '0.22'
   source:
@@ -122,12 +201,32 @@ gems:
     revision: 3670834268f4ea9c10aefeffae7e072b51256375
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: singleton
+  version: '0'
+  source:
+    type: stdlib
 - name: strscan
   version: '0'
   source:
     type: stdlib
 - name: thor
   version: '1.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 3670834268f4ea9c10aefeffae7e072b51256375
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: timeout
+  version: '0'
+  source:
+    type: stdlib
+- name: tzinfo
+  version: '2.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
@@ -150,19 +249,4 @@ gems:
     revision: 3670834268f4ea9c10aefeffae7e072b51256375
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: monitor
-  version: '0'
-  source:
-    type: stdlib
-- name: mutex_m
-  version: '0'
-  source:
-    type: stdlib
-- name: fileutils
-  version: '0'
-  source:
-    type: stdlib
-- name: optparse
-  version: '0'
-  source:
-    type: stdlib
+gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,4 +1,9 @@
 ---
+sources:
+- name: ruby/gem_rbs_collection
+  remote: https://github.com/ruby/gem_rbs_collection.git
+  revision: main
+  repo_dir: gems
 path: ".gem_rbs_collection"
 gems:
 - name: addressable
@@ -25,10 +30,6 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: fileutils
-  version: '0'
-  source:
-    type: stdlib
 - name: hashdiff
   version: '1.1'
   source:
@@ -46,18 +47,6 @@ gems:
   source:
     type: stdlib
 - name: minitest
-  version: '0'
-  source:
-    type: stdlib
-- name: monitor
-  version: '0'
-  source:
-    type: stdlib
-- name: mutex_m
-  version: '0'
-  source:
-    type: stdlib
-- name: optparse
   version: '0'
   source:
     type: stdlib
@@ -101,10 +90,6 @@ gems:
     revision: 3670834268f4ea9c10aefeffae7e072b51256375
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: ripper
-  version: '0'
-  source:
-    type: stdlib
 - name: rubocop
   version: '1.57'
   source:
@@ -165,4 +150,19 @@ gems:
     revision: 3670834268f4ea9c10aefeffae7e072b51256375
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-gemfile_lock_path: Gemfile.lock
+- name: monitor
+  version: '0'
+  source:
+    type: stdlib
+- name: mutex_m
+  version: '0'
+  source:
+    type: stdlib
+- name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
+  version: '0'
+  source:
+    type: stdlib

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -1,14 +1,9 @@
 # Download sources
 sources:
-  - type: git
-    name: ruby/gem_rbs_collection
+  - name: ruby/gem_rbs_collection
     remote: https://github.com/ruby/gem_rbs_collection.git
     revision: main
     repo_dir: gems
-
-# You can specify local directories as sources also.
-# - type: local
-#   path: path/to/your/local/repository
 
 # A directory to install the downloaded RBSs
 path: .gem_rbs_collection
@@ -17,8 +12,4 @@ gems:
   # Skip loading rbs gem's RBS.
   # It's unnecessary if you don't use rbs as a library.
   - name: rbs
-    ignore: true
-  - name: steep
-    ignore: true
-  - name: ruby_lib_core
     ignore: true

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -1,0 +1,24 @@
+# Download sources
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    revision: main
+    repo_dir: gems
+
+# You can specify local directories as sources also.
+# - type: local
+#   path: path/to/your/local/repository
+
+# A directory to install the downloaded RBSs
+path: .gem_rbs_collection
+
+gems:
+  # Skip loading rbs gem's RBS.
+  # It's unnecessary if you don't use rbs as a library.
+  - name: rbs
+    ignore: true
+  - name: steep
+    ignore: true
+  - name: ruby_lib_core
+    ignore: true

--- a/sig/gems/selenium/abstract_event_listener.rbs
+++ b/sig/gems/selenium/abstract_event_listener.rbs
@@ -1,0 +1,8 @@
+module Selenium
+  module WebDriver
+    module Support
+      class AbstractEventListener
+      end
+    end
+  end
+end

--- a/sig/gems/selenium/capabilities.rbs
+++ b/sig/gems/selenium/capabilities.rbs
@@ -1,0 +1,8 @@
+module Selenium
+  module WebDriver
+    module Remote
+        class Capabilities
+        end
+    end
+  end
+end

--- a/sig/gems/selenium/default.rbs
+++ b/sig/gems/selenium/default.rbs
@@ -1,0 +1,10 @@
+module Selenium
+  module WebDriver
+    module Remote
+      module Http
+        class Default
+        end
+      end
+    end
+  end
+end

--- a/sig/gems/selenium/driver.rbs
+++ b/sig/gems/selenium/driver.rbs
@@ -1,0 +1,7 @@
+module Selenium
+  module WebDriver
+    class Driver
+      def capabilities: () -> untyped
+    end
+  end
+end

--- a/sig/gems/selenium/has_session_id.rbs
+++ b/sig/gems/selenium/has_session_id.rbs
@@ -1,0 +1,8 @@
+module Selenium
+  module WebDriver
+    module DriverExtensions
+      module HasSessionId
+      end
+    end
+  end
+end

--- a/sig/gems/selenium/has_web_storage.rbs
+++ b/sig/gems/selenium/has_web_storage.rbs
@@ -1,0 +1,8 @@
+module Selenium
+  module WebDriver
+    module DriverExtensions
+      module HasWebStorage
+      end
+    end
+  end
+end

--- a/sig/gems/selenium/uploads_files.rbs
+++ b/sig/gems/selenium/uploads_files.rbs
@@ -1,0 +1,8 @@
+module Selenium
+  module WebDriver
+    module DriverExtensions
+      module UploadsFiles
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core.rbs
+++ b/sig/lib/appium_lib_core.rbs
@@ -1,0 +1,8 @@
+module Appium
+  def self.symbolize_keys: (Hash[untyped, untyped] hash, ?nested: bool, ?enable_deprecation_msg: bool)
+    -> Hash[Symbol, untyped]
+
+  module Core
+    def self.for: (*untyped args) -> Driver
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/capabilities.rbs
+++ b/sig/lib/appium_lib_core/common/base/capabilities.rbs
@@ -1,0 +1,9 @@
+module Appium
+  module Core
+    class Base
+      class Capabilities < Selenium::WebDriver::Remote::Capabilities
+        def convert_key: (untyped key) -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/driver.rbs
+++ b/sig/lib/appium_lib_core/common/base/driver.rbs
@@ -1,0 +1,167 @@
+module Appium
+  module Core
+    class Base
+      class Driver < Selenium::WebDriver::Driver
+        @wait_timeout: untyped
+
+        @wait_interval: untyped
+
+        @devtools: untyped
+
+        @bidi: untyped
+
+        @bridge: untyped
+
+        @settings: untyped
+
+        @ime: untyped
+
+        @logs: untyped
+
+        include Selenium::WebDriver::DriverExtensions::UploadsFiles
+
+        include Selenium::WebDriver::DriverExtensions::HasSessionId
+
+        include Selenium::WebDriver::DriverExtensions::HasWebStorage
+
+        include Base::Rotatable
+
+        include Base::TakesScreenshot
+
+        include Base::HasRemoteStatus
+
+        include Base::HasLocation
+
+        include Base::HasNetworkConnection
+
+        include Core::Waitable
+
+        attr_reader bridge: untyped
+
+        def initialize: (?bridge: untyped?, ?listener: untyped?, **untyped opts) -> void
+
+        private
+
+        def create_bridge: (**untyped opts) -> untyped
+
+        public
+
+        def update_sending_request_to: (protocol: untyped, host: untyped, port: untyped, path: untyped) -> (nil | untyped)
+
+        AVAILABLE_METHODS: ::Array[:get | :head | :post | :put | :delete | :connect | :options | :trace | :patch]
+
+        def add_command: (method: untyped, url: untyped, name: untyped) { () -> untyped } -> untyped
+
+        def key_action: (?async: bool) -> untyped
+
+        def lock: (?untyped? duration) -> untyped
+
+        def locked?: () -> untyped
+
+        alias device_locked? locked?
+
+        def unlock: () -> untyped
+
+        def hide_keyboard: (?untyped? close_key, ?untyped? strategy) -> untyped
+
+        def keyboard_shown?: () -> untyped
+
+        alias is_keyboard_shown keyboard_shown?
+
+        def settings: () -> untyped
+
+        def get_settings: () -> untyped
+
+        def settings=: (untyped value) -> untyped
+
+        alias update_settings settings=
+
+        def ime: () -> untyped
+
+        def ime_activate: (untyped ime_name) -> untyped
+
+        def ime_available_engines: () -> untyped
+
+        def ime_active_engine: () -> untyped
+
+        def ime_activated: () -> untyped
+
+        def ime_deactivate: () -> untyped
+
+        def within_context: (untyped context) ?{ () -> untyped } -> untyped
+
+        def current_context: () -> untyped
+
+        def available_contexts: () -> untyped
+
+        def context=: (?untyped? context) -> untyped
+
+        alias set_context context=
+
+        def push_file: (untyped path, untyped filedata) -> untyped
+
+        def pull_file: (untyped path) -> untyped
+
+        def pull_folder: (untyped path) -> untyped
+
+        def press_keycode: (untyped key, ?metastate: untyped, ?flags: untyped) -> untyped
+
+        def long_press_keycode: (untyped key, ?metastate: untyped, ?flags: untyped) -> untyped
+
+        def app_strings: (?untyped? language) -> untyped
+
+        def background_app: (?::Integer duration) -> untyped
+
+        def install_app: (untyped path, **untyped options) -> untyped
+
+        def remove_app: (untyped app_id, ?keep_data: untyped?, ?timeout: untyped?) -> untyped
+
+        def app_installed?: (untyped app_id) -> untyped
+
+        def activate_app: (untyped app_id) -> untyped
+
+        def terminate_app: (untyped app_id, ?timeout: untyped?) -> untyped
+
+        def app_state: (untyped app_id) -> untyped
+
+        alias query_app_state app_state
+
+        def stop_recording_screen: (?remote_path: untyped?, ?user: untyped?, ?pass: untyped?, ?method: ::String) -> untyped
+
+        def stop_and_save_recording_screen: (untyped file_path) -> untyped
+
+        def shake: () -> untyped
+
+        def device_time: (?untyped? format) -> untyped
+
+        def perform_actions: (untyped data) -> nil
+
+        def window_size: () -> untyped
+
+        def window_rect: () -> untyped
+
+        def back: () -> untyped
+
+        def logs: () -> untyped
+
+        def get_timeouts: () -> untyped
+
+        def match_images_features: (first_image: untyped, second_image: untyped, ?detector_name: ::String, ?match_func: ::String, ?good_matches_factor: untyped?, ?visualize: bool) -> untyped
+
+        def find_image_occurrence: (full_image: untyped, partial_image: untyped, ?visualize: bool, ?threshold: untyped?, ?multiple: untyped?, ?match_neighbour_threshold: untyped?) -> untyped
+
+        def get_images_similarity: (first_image: untyped, second_image: untyped, ?visualize: bool) -> untyped
+
+        def compare_images: (first_image: untyped, second_image: untyped, ?mode: ::Symbol, ?options: untyped?) -> untyped
+
+        def find_element_by_image: (untyped img_path) -> untyped
+
+        def find_elements_by_image: (untyped img_path) -> untyped
+
+        def execute_driver: (?script: ::String, ?type: ::String, ?timeout_ms: untyped?) -> untyped
+
+        def convert_to_element: (untyped response_id) -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/driver_settings.rbs
+++ b/sig/lib/appium_lib_core/common/base/driver_settings.rbs
@@ -1,0 +1,15 @@
+module Appium
+  module Core
+    class Base
+      class DriverSettings
+        @bridge: untyped
+
+        def initialize: (untyped bridge) -> void
+
+        def get: () -> untyped
+
+        def update: (untyped settings) -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/has_location.rbs
+++ b/sig/lib/appium_lib_core/common/base/has_location.rbs
@@ -1,0 +1,13 @@
+module Appium
+  module Core
+    class Base
+      module HasLocation
+        def location: () -> untyped
+
+        def location=: (untyped location) -> untyped
+
+        def set_location: (untyped latitude, untyped longitude, untyped altitude, ?speed: untyped?, ?satellites: untyped?) -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/has_network_connection.rbs
+++ b/sig/lib/appium_lib_core/common/base/has_network_connection.rbs
@@ -1,0 +1,19 @@
+module Appium
+  module Core
+    class Base
+      module HasNetworkConnection
+        def network_connection_type: () -> untyped
+
+        def network_connection_type=: (untyped connection_type) -> untyped
+
+        private
+
+        def type_to_values: () -> Hash[Symbol, Integer]
+
+        def values_to_type: () -> untyped
+
+        def valid_type?: (untyped type) -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/http_default.rbs
+++ b/sig/lib/appium_lib_core/common/base/http_default.rbs
@@ -1,0 +1,38 @@
+module Appium
+  module Core
+    class Base
+      module Http
+        module RequestHeaders
+          KEYS: Hash[Symbol, String]
+        end
+
+        class Default < Selenium::WebDriver::Remote::Http::Default
+          @open_timeout: untyped
+
+          @read_timeout: untyped
+
+          @additional_headers: untyped
+
+          @http: untyped
+
+          @server_url: untyped
+
+          attr_reader additional_headers: untyped
+
+          # override
+          def initialize: (?open_timeout: untyped?, ?read_timeout: untyped?) -> void
+
+          def set_additional_header: (untyped key, untyped value) -> untyped
+
+          def delete_additional_header: (untyped key) -> untyped
+
+          def update_sending_request_to: (scheme: untyped, host: untyped, port: untyped, path: untyped) -> untyped
+
+          private
+
+          def validate_url_param: (untyped scheme, untyped host, untyped port, untyped path) -> bool
+        end
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/platform.rbs
+++ b/sig/lib/appium_lib_core/common/base/platform.rbs
@@ -1,0 +1,7 @@
+module Appium
+  module Core
+    class Base
+      def self.platform: () -> untyped
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/remote_status.rbs
+++ b/sig/lib/appium_lib_core/common/base/remote_status.rbs
@@ -1,0 +1,9 @@
+module Appium
+  module Core
+    class Base
+      module HasRemoteStatus
+        def remote_status: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/rotable.rbs
+++ b/sig/lib/appium_lib_core/common/base/rotable.rbs
@@ -1,0 +1,17 @@
+module Appium
+  module Core
+    class Base
+      module Rotatable
+        ORIENTATIONS: Array[Symbol]
+
+        def rotation=: (untyped orientation) -> untyped
+
+        alias rotate rotation=
+
+        alias orientation= rotation=
+
+        def orientation: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/base/screenshot.rbs
+++ b/sig/lib/appium_lib_core/common/base/screenshot.rbs
@@ -1,0 +1,19 @@
+module Appium
+  module Core
+    class Base
+      module TakesScreenshot
+        def save_screenshot: (untyped png_path) -> untyped
+
+        def screenshot_as: (untyped format) -> untyped
+
+        def save_element_screenshot: (untyped element, untyped png_path) -> untyped
+
+        alias take_element_screenshot save_element_screenshot
+
+        def element_screenshot_as: (untyped element, untyped format) -> untyped
+
+        def save_viewport_screenshot: (untyped png_path) -> untyped
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/wait.rbs
+++ b/sig/lib/appium_lib_core/common/wait.rbs
@@ -1,0 +1,31 @@
+module Appium
+  module Core
+    module Wait
+      class TimeoutError < StandardError
+      end
+
+      DEFAULT_TIMEOUT: Integer
+
+      DEFAULT_INTERVAL: Float
+
+      def self.until: (?timeout: untyped, ?interval: untyped, ?message: untyped?, ?ignored: untyped?, ?object: untyped?) { (untyped) -> untyped } -> untyped
+
+      def self.until_true: (?timeout: untyped, ?interval: untyped, ?message: untyped?, ?ignored: untyped?, ?object: untyped?) { (untyped) -> untyped } -> untyped
+
+      private
+
+      def self.message_for: (untyped timeout, untyped message) -> untyped
+    end
+
+    module Waitable
+
+      def wait_until_true: (?timeout: untyped?, ?interval: untyped?, ?message: untyped?, ?ignored: untyped?) { (?) -> untyped } -> untyped
+
+      alias wait_true wait_until_true
+
+      def wait_until: (?timeout: untyped?, ?interval: untyped?, ?message: untyped?, ?ignored: untyped?) { (?) -> untyped } -> untyped
+
+      alias wait wait_until
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/device.rbs
+++ b/sig/lib/appium_lib_core/device.rbs
@@ -1,0 +1,21 @@
+module Appium
+  module Core
+    module Device
+      extend Forwardable
+
+      def self.extended: (untyped _mod) -> untyped
+
+      def self.add_endpoint_method: (untyped method) ?{ () -> untyped } -> untyped
+
+      def self.extend_webdriver_with_forwardable: () -> (nil | untyped)
+
+      private
+
+      def self.delegate_from_appium_driver: (untyped method, Symbol? delegation_target) -> (nil | untyped)
+
+      def self.delegate_driver_method: (untyped method) -> (nil | untyped)
+
+      def self.create_bridge_command: (untyped method) ?{ () -> untyped } -> untyped
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/driver.rbs
+++ b/sig/lib/appium_lib_core/driver.rbs
@@ -1,0 +1,200 @@
+module Appium
+  Location: Class
+
+  module Core
+    module Android
+    end
+
+    module Ios
+    end
+
+    class Options
+      @custom_url: String
+
+      @default_wait: Integer
+
+      @enable_idempotency_header: bool
+
+      @direct_connect: bool
+
+      @port: Integer
+
+      @wait_timeout: Integer
+
+      @wait_interval: Integer
+
+      @listener: Selenium::WebDriver::Support::AbstractEventListener
+
+      attr_reader custom_url: String
+
+      attr_reader default_wait: Integer
+
+      attr_reader port: Integer
+
+      attr_reader wait_timeout: Integer
+
+      attr_reader wait_interval: Integer
+
+      attr_reader listener: Selenium::WebDriver::Support::AbstractEventListener
+
+      attr_reader direct_connect: bool
+
+      attr_reader enable_idempotency_header: bool
+
+      def initialize: (Hash[Symbol, String] appium_lib_opts) -> void
+
+      private
+
+      def default_tmp_appium_lib_session: () -> String
+    end
+
+    class DirectConnections
+      @protocol: String
+
+      @host: String
+
+      @port: String
+
+      @path: String
+
+      KEYS: Hash[String | Symbol, String]
+
+      W3C_KEYS: Hash[String | Symbol, String]
+
+      attr_reader protocol: String
+
+      attr_reader host: String
+
+      attr_reader port: String
+
+      attr_reader path: String
+
+      def initialize: (Hash[String | Symbol, String] capabilities) -> void
+    end
+
+    class Driver
+      @delegate_target: self
+
+      @automation_name: Symbol
+
+      @custom_url: String
+
+      @caps: Hash[Symbol | String, Symbol | String | Integer]
+
+      @http_client: Core::Base::Http::Default
+
+      @driver: Core::Base::Driver
+
+      @device: Symbol | String
+
+      @enable_idempotency_header: bool
+
+      @default_wait: Integer
+
+      @port: Integer
+
+      @wait_timeout: Integer
+
+      @wait_interval: Integer
+
+      @listener: Selenium::WebDriver::Support::AbstractEventListener
+
+      @direct_connect: bool
+
+      include Waitable
+
+      attr_reader caps: Base::Capabilities
+
+      attr_reader http_client: Base::Http::Default
+
+      attr_reader enable_idempotency_header: bool
+
+      attr_reader device: Symbol
+
+      attr_reader automation_name: Symbol
+
+      attr_reader custom_url: String
+
+      attr_reader default_wait: Integer
+
+      attr_reader port: Integer
+
+      DEFAULT_APPIUM_PORT: Integer
+
+      attr_reader wait_timeout: Integer
+
+      attr_reader wait_interval: Integer
+
+      attr_reader listener: Selenium::WebDriver::Support::AbstractEventListener
+
+      attr_reader driver: Core::Base::Driver
+
+      attr_reader direct_connect: bool
+
+      def self.for: (Hash[Symbol, Symbol | String | Hash[Symbol, String | Numeric] | Numeric] opts) -> Driver
+
+      def self.attach_to: (
+          String session_id,
+          ?url: String?,
+          ?automation_name: Symbol,
+          ?platform_name: String?,
+          ?http_client_ops:
+          Hash[Symbol, Symbol | String | Hash[Symbol, String | Numeric] | Numeric]
+        ) -> Selenium::WebDriver
+
+      private
+
+      def delegated_target_for_test: () -> self
+
+      def initialize: () -> void
+
+      public
+
+      def setup_for_new_session: (?Hash[Symbol, Symbol | String | Hash[Symbol, String | Numeric] | Numeric] opts) -> self
+
+      def start_driver: (?server_url: untyped?, ?http_client_ops: ::Hash[untyped, untyped]) -> untyped
+
+      def attach_to: (untyped session_id, ?url: untyped?, ?automation_name: Symbol, ?platform_name: untyped?, ?http_client_ops: Hash[untyped, untyped]) -> untyped
+
+      def get_http_client: (?http_client: untyped?, ?open_timeout: untyped?, ?read_timeout: untyped?) -> untyped
+
+      def set_implicit_wait_by_default: (untyped wait) -> untyped
+
+      def quit_driver: () -> void
+
+      def appium_server_version: () -> Hash[String, String]
+
+      private
+
+      def convert_to_symbol: (untyped? value) -> Symbol
+
+      def extend_for: (device: Symbol | String, automation_name: Symbol) -> self
+
+      extend Core
+
+      extend Core::Device
+
+      def get_caps: (Hash[Symbol, Symbol | String | Hash[Symbol, String | Numeric] | Numeric]? opts)
+        -> Core::Base::Capabilities
+
+      def get_appium_lib_opts: (Hash[Symbol, Symbol | String | Hash[Symbol, String | Numeric] | Numeric]? opts)
+        -> (Symbol | String | Hash[Symbol, String | Numeric] | Numeric)
+
+      def get_app: () -> String?
+
+      def set_app_path: () -> String?
+
+      def set_appium_lib_specific_values: (
+          Hash[Symbol, Symbol | String | Hash[Symbol, String | Numeric] | Numeric]? appium_lib_opts
+        ) -> self
+
+      def set_appium_device: () -> String
+
+      def set_automation_name: () -> Symbol?
+
+      def convert_downcase: (Symbol value) -> Symbol
+
+      def set_automation_name_if_nil: () -> Symbol?
+    end
+  end
+end


### PR DESCRIPTION
### Description
This PR is the first of several PRs to add RBS support to the full ruby_lib_core project

Key things added to this PR:

- Steep gem as a development dependency:

  - Steep is a type validation gem https://github.com/soutaro/steep, that depends on RBS and typeprof, the goal of steep is to allow us to check for type issues

- RBS gem collection: Several commonly used gems do not have RBS files, so the ruby community created a collection used by RBS to avoid us having to declare all the commonly used gems every time: https://github.com/ruby/gem_rbs_collection

- Sig folder: This is the signature folder and is where all of our RBS files will be located

- Rake task to run type checks: there is a rake task now, named steep that makes it easier to run a check from your preferred IDE

- Steepfile: this file contains all the configuration on how steep is going to perform the type check and against want

Screenshot of a type check:

<img width="1648" alt="Screenshot 2024-07-22 at 20 58 51" src="https://github.com/user-attachments/assets/698eb7e0-bed7-440c-b329-42f1f1104469">

How did I decide what signatures to add?:

- I did this based on the idea of having a minimum amount of coverage to start working and show the value since for example, Appium::Core::Driver is dependent on several modules and classes I needed to add all of them to avoid steep to fail due to missing modules and not check the types

### Motivation and Context

We want to add type support to the core library as specified here #296 so it's easier for new contributors to understand what the methods are expecting and returning.

We also want eventually to be able to run automatic type checks to avoid type errors, and we would like for the RBS files to serve as documentation so the contributors do not need to write as many comments and speed up their flow.

