### PR TITLE
feat: Take down steep issues from 589 to 552

### DIFF
--- a/sig/gems/selenium/common.rbs
+++ b/sig/gems/selenium/common.rbs
@@ -1,0 +1,10 @@
+module Selenium
+  module WebDriver
+    module Remote
+      module Http
+        class Common
+        end
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/common/device/battery_status.rbs
+++ b/sig/lib/appium_lib_core/common/device/battery_status.rbs
@@ -1,0 +1,13 @@
+module Appium
+  module Core
+    class Base
+      module Device
+        module BatteryStatus
+          ANDROID: Array[Symbol]
+
+          IOS: Array[Symbol]
+        end
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/ios/xcuitest/device/battery.rbs
+++ b/sig/lib/appium_lib_core/ios/xcuitest/device/battery.rbs
@@ -1,0 +1,15 @@
+module Appium
+  module Core
+    module Ios
+      module Xcuitest
+        module Device
+          module Battery
+            def self.add_methods: () -> (Symbol | Hash[Symbol, Proc])?
+
+            def battery_info: () -> (Symbol | Hash[Symbol, Proc])?
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/lib/appium_lib_core/version.rbs
+++ b/sig/lib/appium_lib_core/version.rbs
@@ -1,0 +1,7 @@
+module Appium
+  module Core
+    VERSION: String
+
+    DATE: String
+  end
+end


### PR DESCRIPTION
### Description
This PR is the second PR in our efforts to bring full RBS support to the ruby_lib_core

The following RBS files are added for the respective classes and modules:

- Common
- Battery
- Battery Status
- Version

Before the PR:

<img width="1158" alt="Screenshot 2024-07-24 at 20 31 09" src="https://github.com/user-attachments/assets/d3efa31b-6113-4152-b0c4-78aa19fc3e9a">

After the PR:

<img width="1113" alt="Screenshot 2024-07-24 at 20 37 43" src="https://github.com/user-attachments/assets/e9bfdf98-ab55-4e42-a1e7-498a9a4e0126">


### Motivation and Context

We want to add type support to the core library as specified here #296 so it's easier for new contributors to understand what the methods are expecting and returning.

We also want eventually to be able to run automatic type checks to avoid type errors, and we would like for the RBS files to serve as documentation so the contributors do not need to write as many comments and speed up their flow.

