### PR TITLE
fix instance variables of device and automation_name

### DIFF
--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -104,7 +104,7 @@ module Appium
     class Driver
       include Waitable
 
-      # Selenium webdriver capabilities
+      # Selenium webdriver capabilities, but the value is provided capabilities basis.
       # @return [Core::Base::Capabilities]
       attr_reader :caps
 
@@ -125,7 +125,7 @@ module Appium
 
       # Automation name sent to appium server or received by server.<br>
       # If automation_name is <code>nil</code>, it is not set both client side and server side.
-      # @return [Hash]
+      # @return [device]
       attr_reader :automation_name
 
       # Custom URL for the selenium server. If set this attribute, ruby_lib_core try to handshake to the custom url.<br>
@@ -624,6 +624,7 @@ module Appium
 
       # @private
       def get_caps(opts)
+        # TODO: drop symbols
         Core::Base::Capabilities.new(opts[:caps] || opts[:capabilities] || {})
       end
 
@@ -634,7 +635,8 @@ module Appium
 
       # @private
       def get_app
-        @caps[:app] || @caps['app']
+        # return symbols only
+        @caps[:app] || @caps['app'] || @caps[:'appium:app'] || @caps['appium:app']
       end
 
       # @private
@@ -681,14 +683,15 @@ module Appium
         @device = @caps[:platformName] || @caps['platformName']
         return @device unless @device
 
-        @device = convert_downcase @device
+        @device = convert_to_symbol(convert_downcase(@device))
       end
 
       # @private
       def set_automation_name
-        candidate = @caps[:automationName] || @caps['automationName']
+        candidate = @caps[:automationName] || @caps['automationName'] ||
+                    @caps[:'appium:automationName'] || @caps['appium:automationName']
         @automation_name = candidate if candidate
-        @automation_name = convert_downcase @automation_name if @automation_name
+        @automation_name = convert_to_symbol(convert_downcase(@automation_name)) if @automation_name
       end
 
       # @private
@@ -700,9 +703,10 @@ module Appium
       def set_automation_name_if_nil
         return unless @automation_name.nil?
 
-        @automation_name = if @driver.capabilities['automationName']
-                             @driver.capabilities['automationName'].downcase.strip.intern
-                           end
+        automation_name = if @driver.capabilities['automationName']
+                            @driver.capabilities['automationName'].downcase.strip.intern
+                          end
+        @automation_name = convert_to_symbol automation_name
       end
     end # class Driver
   end # module Core

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -125,7 +125,7 @@ module Appium
 
       # Automation name sent to appium server or received by server.<br>
       # If automation_name is <code>nil</code>, it is not set both client side and server side.
-      # @return [device]
+      # @return [Symbol]
       attr_reader :automation_name
 
       # Custom URL for the selenium server. If set this attribute, ruby_lib_core try to handshake to the custom url.<br>

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -624,7 +624,6 @@ module Appium
 
       # @private
       def get_caps(opts)
-        # TODO: drop symbols
         Core::Base::Capabilities.new(opts[:caps] || opts[:capabilities] || {})
       end
 
@@ -635,8 +634,7 @@ module Appium
 
       # @private
       def get_app
-        # return symbols only
-        @caps[:app] || @caps['app'] || @caps[:'appium:app'] || @caps['appium:app']
+        get_cap 'app'
       end
 
       # @private
@@ -680,7 +678,7 @@ module Appium
       # @private
       def set_appium_device
         # https://code.google.com/p/selenium/source/browse/spec-draft.md?repo=mobile
-        @device = @caps[:platformName] || @caps['platformName']
+        @device = get_cap 'platformName'
         return @device unless @device
 
         @device = convert_to_symbol(convert_downcase(@device))
@@ -688,8 +686,7 @@ module Appium
 
       # @private
       def set_automation_name
-        candidate = @caps[:automationName] || @caps['automationName'] ||
-                    @caps[:'appium:automationName'] || @caps['appium:automationName']
+        candidate = get_cap 'automationName'
         @automation_name = candidate if candidate
         @automation_name = convert_to_symbol(convert_downcase(@automation_name)) if @automation_name
       end
@@ -707,6 +704,14 @@ module Appium
                             @driver.capabilities['automationName'].downcase.strip.intern
                           end
         @automation_name = convert_to_symbol automation_name
+      end
+
+      def get_cap(name)
+        name_with_prefix = "appium:#{name}"
+        @caps[convert_to_symbol name] ||
+          @caps[name] ||
+          @caps[convert_to_symbol name_with_prefix] ||
+          @caps[name_with_prefix]
       end
     end # class Driver
   end # module Core

--- a/test/unit/appium_lib_core_test.rb
+++ b/test/unit/appium_lib_core_test.rb
@@ -64,6 +64,42 @@ class AppiumLibCoreTest
       assert_equal 'symbolize_keys requires a hash', e.message
     end
 
+    def test_core_instance_variables
+      opts = {
+        url: 'http://custom-host:8080/wd/hub.com',
+        caps: {
+          platformName: :ios,
+          platformVersion: '11.0',
+          deviceName: 'iPhone Simulator',
+          automationName: 'XCUITest',
+          app: '/path/to/MyiOS.app'
+        }
+      }
+      @core = Appium::Core.for(opts)
+      assert_equal 'http://custom-host:8080/wd/hub.com', @core.custom_url
+
+      assert_equal :ios, @core.device
+      assert_equal :xcuitest, @core.automation_name
+    end
+
+    def test_core_instance_variables_with_appium_prefix
+      opts = {
+        url: 'http://custom-host:8080/wd/hub.com',
+        caps: {
+          'platformName': 'ios',
+          'appium:platformVersion': '11.0',
+          'appium:deviceName': 'iPhone Simulator',
+          'appium:automationName': 'XCUITest',
+          'appium:app': '/path/to/MyiOS.app'
+        }
+      }
+      @core = Appium::Core.for(opts)
+      assert_equal 'http://custom-host:8080/wd/hub.com', @core.custom_url
+
+      assert_equal :ios, @core.device
+      assert_equal :xcuitest, @core.automation_name
+    end
+
     def test_url_param
       opts = {
         url: 'http://custom-host:8080/wd/hub.com',

--- a/test/unit/appium_lib_core_test.rb
+++ b/test/unit/appium_lib_core_test.rb
@@ -82,7 +82,7 @@ class AppiumLibCoreTest
       assert_equal :xcuitest, @core.automation_name
     end
 
-    def test_core_instance_variables_with_appium_prefix
+    def test_core_instance_variables_with_appium_prefix_hash
       opts = {
         url: 'http://custom-host:8080/wd/hub.com',
         caps: {
@@ -100,6 +100,23 @@ class AppiumLibCoreTest
       assert_equal :xcuitest, @core.automation_name
     end
 
+    def test_core_instance_variables_with_appium_prefix_string
+      opts = {
+        url: 'http://custom-host:8080/wd/hub.com',
+        caps: {
+          'platformName' => 'ios',
+          'appium:platformVersion' => '11.0',
+          'appium:deviceName' => 'iPhone Simulator',
+          'appium:automationName' => 'XCUITest',
+          'appium:app' => '/path/to/MyiOS.app'
+        }
+      }
+      @core = Appium::Core.for(opts)
+      assert_equal 'http://custom-host:8080/wd/hub.com', @core.custom_url
+
+      assert_equal :ios, @core.device
+      assert_equal :xcuitest, @core.automation_name
+    end
     def test_url_param
       opts = {
         url: 'http://custom-host:8080/wd/hub.com',

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -79,6 +79,23 @@ class AppiumLibCoreTest
       assert_equal 'someCapability2', caps[:someCapability2]
     end
 
+    def test_verify_appium_core_base_capabilities_create_capabilities_with_caps
+      caps = ::Appium::Core::Base::Capabilities.new(platformName: 'ios',
+                                                    'appium:platformVersion': '11.4',
+                                                    'appium:automationName': 'XCUITest',
+                                                    'appium:app': 'test/functional/app/UICatalog.app.zip')
+
+      caps_with_json = JSON.parse(caps.to_json)
+      puts(caps_with_json)
+      assert_equal 'ios', caps_with_json['platformName']
+      assert_equal 'XCUITest', caps_with_json['appium:automationName']
+      assert_equal 'test/functional/app/UICatalog.app.zip', caps_with_json['appium:app']
+
+      assert_equal 'ios', caps[:platformName]
+      assert_equal 'XCUITest', caps[:'appium:automationName']
+      assert_equal 'test/functional/app/UICatalog.app.zip', caps[:'appium:app']
+    end
+
     def test_default_wait
       assert_equal 5, @core.default_wait
     end

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -79,14 +79,13 @@ class AppiumLibCoreTest
       assert_equal 'someCapability2', caps[:someCapability2]
     end
 
-    def test_verify_appium_core_base_capabilities_create_capabilities_with_caps
+    def test_verify_appium_core_base_capabilities_create_capabilities_with_caps_hash
       caps = ::Appium::Core::Base::Capabilities.new(platformName: 'ios',
                                                     'appium:platformVersion': '11.4',
                                                     'appium:automationName': 'XCUITest',
                                                     'appium:app': 'test/functional/app/UICatalog.app.zip')
 
       caps_with_json = JSON.parse(caps.to_json)
-      puts(caps_with_json)
       assert_equal 'ios', caps_with_json['platformName']
       assert_equal 'XCUITest', caps_with_json['appium:automationName']
       assert_equal 'test/functional/app/UICatalog.app.zip', caps_with_json['appium:app']
@@ -94,6 +93,22 @@ class AppiumLibCoreTest
       assert_equal 'ios', caps[:platformName]
       assert_equal 'XCUITest', caps[:'appium:automationName']
       assert_equal 'test/functional/app/UICatalog.app.zip', caps[:'appium:app']
+    end
+
+    def test_verify_appium_core_base_capabilities_create_capabilities_with_caps_string
+      caps = ::Appium::Core::Base::Capabilities.new('platformName' => 'ios',
+                                                    'appium:platformVersion' => '11.4',
+                                                    'appium:automationName' => 'XCUITest',
+                                                    'appium:app' => 'test/functional/app/UICatalog.app.zip')
+
+      caps_with_json = JSON.parse(caps.to_json)
+      assert_equal 'ios', caps_with_json['platformName']
+      assert_equal 'XCUITest', caps_with_json['appium:automationName']
+      assert_equal 'test/functional/app/UICatalog.app.zip', caps_with_json['appium:app']
+
+      assert_equal 'ios', caps['platformName']
+      assert_equal 'XCUITest', caps['appium:automationName']
+      assert_equal 'test/functional/app/UICatalog.app.zip', caps['appium:app']
     end
 
     def test_default_wait


### PR DESCRIPTION
fixes https://github.com/appium/ruby_lib_core/issues/569

This fix will fix ruby_lib as well. e.g. https://github.com/appium/ruby_lib/blob/0d1c2b87b8f2ac456372bf4cbb2441fffae5cf27/lib/appium_lib/driver.rb#L208-L243