### PR TITLE
feat: use /se/log and /se/log/types for logs

### DIFF
--- a/lib/appium_lib_core/common/command.rb
+++ b/lib/appium_lib_core/common/command.rb
@@ -171,9 +171,9 @@ module Appium
         ime_deactivate: [:post, 'session/:session_id/ime/deactivate'],
         ime_activate_engine: [:post, 'session/:session_id/ime/activate'],
 
-        ### Logs
-        get_available_log_types: [:get, 'session/:session_id/log/types'],
-        get_log: [:post, 'session/:session_id/log'],
+        ### Logs based on w3c selenium clients
+        get_available_log_types: [:get, 'session/:session_id/se/log/types'],
+        get_log: [:post, 'session/:session_id/se/log'],
 
         ###
         # Appium own

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -622,7 +622,9 @@ module Appium
       def set_app_path
         # FIXME: maybe `:app` should check `app` as well.
         return unless @caps && get_app && !get_app.empty?
-        return if get_app =~ URI::RFC2396_PARSER.make_regexp
+
+        uri_regex = defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::DEFAULT_PARSER
+        return if get_app =~ uri_regex.make_regexp
 
         app_path = File.expand_path(get_app)
         @caps['app'] = if File.exist? app_path

--- a/lib/appium_lib_core/driver.rb
+++ b/lib/appium_lib_core/driver.rb
@@ -622,7 +622,7 @@ module Appium
       def set_app_path
         # FIXME: maybe `:app` should check `app` as well.
         return unless @caps && get_app && !get_app.empty?
-        return if get_app =~ URI::DEFAULT_PARSER.make_regexp
+        return if get_app =~ URI::RFC2396_PARSER.make_regexp
 
         app_path = File.expand_path(get_app)
         @caps['app'] = if File.exist? app_path

--- a/test/unit/driver_test.rb
+++ b/test/unit/driver_test.rb
@@ -49,7 +49,7 @@ class AppiumLibCoreTest
       opts = { 'caps' => { 'automationName': 'xcuitest' }, appium_lib: {} }
       driver = ExampleDriver.new(opts)
       refute_nil driver
-      assert_equal driver.core.caps[:automationName], nil
+      assert_nil driver.core.caps[:automationName]
     end
 
     def test_verify_appium_core_base_capabilities_create_capabilities


### PR DESCRIPTION
Replace the endpoint call from `session/:session_id/log/types` to `session/:session_id/se/log/types`. This should not cause any issues recent Appium versions. Possibly old one such as Appium 1.20 or lower, or around could have an issue but they are pretty old today.