### PR TITLE
feat: remove unnecessary code only for ruby_lib

### DIFF
--- a/lib/appium_lib_core/device.rb
+++ b/lib/appium_lib_core/device.rb
@@ -20,26 +20,6 @@ module Appium
       class << self
         def extended(_mod)
           extend_webdriver_with_forwardable
-
-          # Compatibility for appium_lib. Below command are extended by `extend Appium::Core::Deivce`in appium_lib.
-          # TODO: Will remove
-          [
-            :take_element_screenshot, :save_viewport_screenshot,
-            :lock, :device_locked?, :unlock,
-            :hide_keyboard, :is_keyboard_shown,
-            :ime_activate, :ime_available_engines, :ime_active_engine, :ime_activated, :ime_deactivate,
-            :get_settings, :update_settings,
-            :within_context, :current_context, :available_contexts, :set_context,
-            :push_file, :pull_file, :pull_folder,
-            :keyevent, :press_keycode, :long_press_keycode,
-            :match_images_features, :find_image_occurrence, :get_images_similarity, :compare_images,
-            :app_strings, :background_app,
-            :install_app, :remove_app, :app_installed?, :activate_app, :terminate_app,
-            :app_state,
-            :stop_recording_screen, :stop_and_save_recording_screen,
-            :shake, :device_time,
-            :execute_driver, :execute_cdp
-          ].each(&method(:delegate_from_appium_driver))
         end
 
         # def extended

--- a/test/unit/android/device/w3c/definition_test.rb
+++ b/test/unit/android/device/w3c/definition_test.rb
@@ -42,44 +42,6 @@ class AppiumLibCoreTest
               delegate_from_appium_driver(v)
             end
           end
-
-          def test_with_arg_definitions
-            parameterized_method_defined_check([:shake,
-                                                :device_locked?,
-                                                :unlock,
-                                                :device_time,
-                                                :current_context,
-                                                :open_notifications,
-                                                :current_activity,
-                                                :current_package,
-                                                :get_system_bars,
-                                                :get_display_density,
-                                                :is_keyboard_shown,
-                                                :available_contexts,
-                                                :set_context,
-                                                :app_strings,
-                                                :lock,
-                                                :install_app,
-                                                :remove_app,
-                                                :app_installed?,
-                                                :terminate_app,
-                                                :activate_app,
-                                                :app_state,
-                                                :background_app,
-                                                :hide_keyboard,
-                                                :keyevent,
-                                                :press_keycode,
-                                                :long_press_keycode,
-                                                :push_file,
-                                                :pull_file,
-                                                :pull_folder,
-                                                :get_settings,
-                                                :update_settings,
-                                                :get_clipboard,
-                                                :set_clipboard,
-                                                :execute_driver,
-                                                :execute_cdp])
-          end
         end # class DefinitionTest
       end # module W3C
     end # module Device

--- a/test/unit/ios/device/w3c/definition_test.rb
+++ b/test/unit/ios/device/w3c/definition_test.rb
@@ -32,10 +32,6 @@ class AppiumLibCoreTest
             assert @driver.respond_to? :device_locked?
           end
 
-          def test_delegate_from_appium_driver
-            assert @core.send(:delegated_target_for_test).respond_to? :device_locked?
-          end
-
           def delegate_from_appium_driver(key)
             assert @core.send(:delegated_target_for_test).respond_to? key
           end
@@ -45,39 +41,6 @@ class AppiumLibCoreTest
               assert ::Appium::Core::Base::Bridge.method_defined?(v)
               delegate_from_appium_driver(v)
             end
-          end
-
-          def test_with_arg_definitions
-            parameterized_method_defined_check([:shake,
-                                                :device_locked?,
-                                                :unlock,
-                                                :device_time,
-                                                :current_context,
-                                                :available_contexts,
-                                                :set_context,
-                                                :app_strings,
-                                                :lock,
-                                                :install_app,
-                                                :remove_app,
-                                                :terminate_app,
-                                                :activate_app,
-                                                :app_state,
-                                                :app_installed?,
-                                                :background_app,
-                                                :hide_keyboard,
-                                                :keyevent,
-                                                :press_keycode,
-                                                :long_press_keycode,
-                                                :push_file,
-                                                :pull_file,
-                                                :pull_folder,
-                                                :get_clipboard,
-                                                :set_clipboard,
-                                                :get_settings,
-                                                :update_settings,
-                                                :touch_id,
-                                                :toggle_touch_id_enrollment,
-                                                :execute_driver])
           end
         end # class DefinitionTest
       end # module W3C


### PR DESCRIPTION
As https://github.com/appium/ruby_lib/pull/1109

An endpoint of 'install_app' was called with this branch from the ruby_lib on my local:

```
[148c5817][HTTP] --> POST /session/148c5817-e116-4ceb-bed3-ea15f2c89bff/appium/device/install_app {"appPath":"/Users/kazu/github/ruby_lib/test_apps/api.apk"}
[148c5817][AndroidUiautomator2Driver@590b] Calling AppiumDriver.installApp() with args: ["/Users/kazu/github/ruby_lib/test_apps/api.apk",null,"148c5817-e116-4ceb-bed3-ea15f2c89bff"]
[148c5817][BaseDriver] Using local app '/Users/kazu/github/ruby_lib/test_apps/api.apk'
[148c5817][ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 install -r /Users/kazu/github/ruby_lib/test_apps/api.apk'
[148c5817][ADB] The installation of 'api.apk' took 6807ms
[148c5817][ADB] Install command stdout: Performing Streamed Install
Success
[148c5817][AndroidUiautomator2Driver@590b] Responding to client with driver.installApp() result: null
[148c5817][HTTP] <-- POST /session/148c5817-e116-4ceb-bed3-ea15f2c89bff/appium/device/install_app 200 6975 ms - 14
```